### PR TITLE
Lazily index LocalCollection documents

### DIFF
--- a/src/dreamsboard/collection/__init__.py
+++ b/src/dreamsboard/collection/__init__.py
@@ -1,0 +1,19 @@
+from dreamsboard.dreamsboard.collection import (  # noqa: F401
+    BaseCollection,
+    LocalCollection,
+    PaperCollection,
+    QueryResult,
+    WebCollection,
+    create_collection,
+    register_collection,
+)
+
+__all__ = [
+    "BaseCollection",
+    "LocalCollection",
+    "PaperCollection",
+    "QueryResult",
+    "WebCollection",
+    "create_collection",
+    "register_collection",
+]

--- a/src/dreamsboard/collection/local_collection.py
+++ b/src/dreamsboard/collection/local_collection.py
@@ -1,0 +1,1 @@
+from dreamsboard.dreamsboard.collection.local_collection import *  # noqa: F401,F403

--- a/src/dreamsboard/collection/paper_collection.py
+++ b/src/dreamsboard/collection/paper_collection.py
@@ -1,0 +1,1 @@
+from dreamsboard.dreamsboard.collection.paper_collection import *  # noqa: F401,F403

--- a/src/dreamsboard/collection/web_collection.py
+++ b/src/dreamsboard/collection/web_collection.py
@@ -1,0 +1,1 @@
+from dreamsboard.dreamsboard.collection.web_collection import *  # noqa: F401,F403

--- a/src/dreamsboard/dreamsboard/collection/__init__.py
+++ b/src/dreamsboard/dreamsboard/collection/__init__.py
@@ -1,0 +1,14 @@
+from .collection import BaseCollection, QueryResult, create_collection, register_collection
+from .local_collection import LocalCollection  # noqa: F401
+from .paper_collection import PaperCollection  # noqa: F401
+from .web_collection import WebCollection  # noqa: F401
+
+__all__ = [
+    "BaseCollection",
+    "QueryResult",
+    "create_collection",
+    "register_collection",
+    "LocalCollection",
+    "PaperCollection",
+    "WebCollection",
+]

--- a/src/dreamsboard/dreamsboard/collection/collection.py
+++ b/src/dreamsboard/dreamsboard/collection/collection.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence
+
+
+@dataclass
+class QueryResult:
+    content: str
+    score: float
+    metadata: Dict[str, Any]
+
+
+class BaseCollection:
+    """Unified collection interface that hides different data sources."""
+
+    def add_texts(
+        self,
+        texts: Sequence[str],
+        metadatas: Optional[Sequence[Dict[str, Any]]] = None,
+    ) -> None:
+        raise NotImplementedError
+
+    def query(self, query: str, top_k: int = 5) -> List[QueryResult]:
+        raise NotImplementedError
+
+
+_COLLECTION_REGISTRY: Dict[str, Callable[..., BaseCollection]] = {}
+
+
+def register_collection(name: str, factory: Callable[..., BaseCollection]) -> None:
+    _COLLECTION_REGISTRY[name] = factory
+
+
+def create_collection(mode: str, **kwargs: Any) -> BaseCollection:
+    try:
+        factory = _COLLECTION_REGISTRY[mode]
+    except KeyError as exc:  # pragma: no cover - defensive branch
+        raise ValueError(f"Unsupported data_base: {mode}") from exc
+    return factory(**kwargs)

--- a/src/dreamsboard/dreamsboard/collection/local_collection.py
+++ b/src/dreamsboard/dreamsboard/collection/local_collection.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any, Dict, List, Optional, Sequence
+from langchain_community.document_loaders import TextLoader
+from langchain_community.document_loaders.directory import DirectoryLoader
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+from dreamsboard.vector.base import DocumentWithVSId
+from dreamsboard.vector.faiss_kb_service import FaissCollectionService
+
+from .collection import BaseCollection, QueryResult, register_collection
+
+
+class LocalCollection(BaseCollection):
+    """Collection backed by local markdown or text documents."""
+
+    def __init__(
+        self,
+        kb_name: str,
+        embed_model: str,
+        vector_name: str,
+        device: str,
+        docs_path: str,
+        glob: str = "**/*.md",
+        chunk_size: int = 800,
+        chunk_overlap: int = 100,
+        encoding: str = "utf-8",
+    ) -> None:
+        self._service = FaissCollectionService(
+            kb_name=kb_name,
+            embed_model=embed_model,
+            vector_name=vector_name,
+            device=device,
+        )
+        self._local_service = FaissCollectionService(
+            kb_name=f"{kb_name}_local",
+            embed_model=embed_model,
+            vector_name=f"{vector_name}_local",
+            device=device,
+        )
+        self._docs_path = docs_path
+        self._glob = glob
+        self._chunk_size = chunk_size
+        self._chunk_overlap = chunk_overlap
+        self._encoding = encoding
+        self._indexed = False
+
+    def _ensure_indexed(self) -> None:
+        if self._indexed:
+            return
+        self._index_local_documents()
+        self._indexed = True
+
+    def _index_local_documents(self) -> None:
+        if not os.path.isdir(self._docs_path):
+            raise ValueError(
+                f"docs_path '{self._docs_path}' does not exist or is not a directory"
+            )
+
+        loader = DirectoryLoader(
+            self._docs_path,
+            glob=self._glob,
+            loader_cls=TextLoader,
+            loader_kwargs={"encoding": self._encoding},
+            use_multithreading=True,
+            show_progress=False,
+        )
+        raw_documents = loader.load()
+        documents = []
+        for item in raw_documents:
+            if isinstance(item, list):
+                documents.extend(item)
+            else:
+                documents.append(item)
+        if not documents:
+            return
+
+        splitter = RecursiveCharacterTextSplitter(
+            chunk_size=self._chunk_size,
+            chunk_overlap=self._chunk_overlap,
+        )
+        chunks = splitter.split_documents(documents)
+        docs_with_ids: List[DocumentWithVSId] = []
+        for index, chunk in enumerate(chunks):
+            metadata = dict(chunk.metadata)
+            source = metadata.get("source") or f"local_{index}"
+            ref_id = metadata.get("ref_id") or source
+            chunk_id = metadata.get("chunk_id") or f"{ref_id}_{index}"
+            metadata.setdefault("ref_id", ref_id)
+            metadata.setdefault("chunk_id", chunk_id)
+            metadata.setdefault("paper_title", os.path.basename(source))
+            docs_with_ids.append(
+                DocumentWithVSId(
+                    id=str(uuid.uuid5(uuid.NAMESPACE_URL, f"{ref_id}_{chunk_id}")),
+                    page_content=chunk.page_content,
+                    metadata=metadata,
+                )
+            )
+        if docs_with_ids:
+            self._local_service.do_clear_vs()
+            self._local_service.do_add_doc(docs_with_ids)
+            self._upsert(docs_with_ids)
+
+    def add_texts(
+        self,
+        texts: Sequence[str],
+        metadatas: Optional[Sequence[Dict[str, Any]]] = None,
+    ) -> None:
+        self._ensure_indexed()
+        docs: List[DocumentWithVSId] = []
+        metadatas = metadatas or [{}] * len(texts)
+        for text, metadata in zip(texts, metadatas):
+            metadata = dict(metadata)
+            ref_id = metadata.get("ref_id") or str(uuid.uuid4())
+            chunk_id = metadata.get("chunk_id") or ref_id
+            metadata.setdefault("ref_id", ref_id)
+            metadata.setdefault("chunk_id", chunk_id)
+            metadata.setdefault("paper_title", metadata.get("paper_title", ""))
+            docs.append(
+                DocumentWithVSId(
+                    id=str(uuid.uuid5(uuid.NAMESPACE_URL, f"{ref_id}_{chunk_id}")),
+                    page_content=text,
+                    metadata=metadata,
+                )
+            )
+        if docs:
+            self._local_service.do_add_doc(docs)
+            self._upsert(docs)
+
+    def _upsert(self, docs: List[DocumentWithVSId]) -> None:
+        if not docs:
+            return
+        existing = self._service.get_doc_by_ids([doc.id for doc in docs])
+        existing_ids = {doc.id for doc in existing}
+        new_docs = [doc for doc in docs if doc.id not in existing_ids]
+        if new_docs:
+            self._service.do_add_doc(new_docs)
+
+    def query(self, query: str, top_k: int = 5) -> List[QueryResult]:
+        self._ensure_indexed()
+        documents = self._local_service.do_search(query=query, top_k=top_k)
+        self._upsert(documents)
+        documents = self._service.do_search(query=query, top_k=top_k)
+        results: List[QueryResult] = []
+        for doc in documents:
+            metadata = dict(doc.metadata)
+            score = metadata.get("score", 0.0)
+            metadata.setdefault("ref_id", metadata.get("ref_id", doc.id))
+            metadata.setdefault("chunk_id", metadata.get("chunk_id", doc.id))
+            metadata.setdefault("paper_title", metadata.get("paper_title", ""))
+            results.append(
+                QueryResult(
+                    content=doc.page_content,
+                    score=score,
+                    metadata=metadata,
+                )
+            )
+        return results
+
+
+register_collection("local_collection", LocalCollection)

--- a/src/dreamsboard/dreamsboard/collection/paper_collection.py
+++ b/src/dreamsboard/dreamsboard/collection/paper_collection.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import uuid
+from typing import Dict, List, Optional, Sequence
+
+from dreamsboard.dreams.task_step_to_question_chain.weaviate.prepare_load import (
+    exe_query,
+)
+from dreamsboard.vector.base import DocumentWithVSId
+from dreamsboard.vector.faiss_kb_service import FaissCollectionService
+
+from .collection import BaseCollection, QueryResult, register_collection
+
+
+class PaperCollection(BaseCollection):
+    def __init__(
+        self,
+        kb_name: str,
+        embed_model: str,
+        vector_name: str,
+        device: str,
+    ) -> None:
+        self._service = FaissCollectionService(
+            kb_name=kb_name,
+            embed_model=embed_model,
+            vector_name=vector_name,
+            device=device,
+        )
+
+    def add_texts(
+        self,
+        texts: Sequence[str],
+        metadatas: Optional[Sequence[Dict[str, Any]]] = None,
+    ) -> None:
+        docs = self._build_documents_from_texts(texts, metadatas)
+        if docs:
+            self._service.do_add_doc(docs)
+
+    def _build_documents_from_texts(
+        self,
+        texts: Sequence[str],
+        metadatas: Optional[Sequence[Dict[str, Any]]],
+    ) -> List[DocumentWithVSId]:
+        metadatas = metadatas or [{}] * len(texts)
+        documents: List[DocumentWithVSId] = []
+        for text, metadata in zip(texts, metadatas):
+            metadata = dict(metadata)
+            ref_id = metadata.get("ref_id") or str(uuid.uuid4())
+            chunk_id = metadata.get("chunk_id") or ref_id
+            metadata.setdefault("paper_title", metadata.get("paper_title", ""))
+            metadata.setdefault("ref_id", ref_id)
+            metadata.setdefault("chunk_id", chunk_id)
+            documents.append(
+                DocumentWithVSId(
+                    id=str(ref_id),
+                    page_content=text,
+                    metadata=metadata,
+                )
+            )
+        return documents
+
+    def _upsert(self, docs: List[DocumentWithVSId]) -> None:
+        if not docs:
+            return
+        existing = self._service.get_doc_by_ids([doc.id for doc in docs])
+        existing_ids = {doc.id for doc in existing}
+        new_docs = [doc for doc in docs if doc.id not in existing_ids]
+        if new_docs:
+            self._service.do_add_doc(new_docs)
+
+    def query(self, query: str, top_k: int = 5) -> List[QueryResult]:
+        properties = exe_query(query, top_k)
+        docs: List[DocumentWithVSId] = []
+        for item in properties:
+            metadata = dict(item)
+            text = metadata.pop("chunk_text", "")
+            ref_id = str(metadata.get("ref_id") or uuid.uuid4())
+            chunk_id = str(metadata.get("chunk_id") or ref_id)
+            metadata.setdefault("paper_title", metadata.get("paper_title", ""))
+            metadata.setdefault("ref_id", ref_id)
+            metadata.setdefault("chunk_id", chunk_id)
+            docs.append(
+                DocumentWithVSId(
+                    id=ref_id,
+                    page_content=text,
+                    metadata=metadata,
+                )
+            )
+        self._upsert(docs)
+        documents = self._service.do_search(query=query, top_k=top_k)
+        results: List[QueryResult] = []
+        for doc in documents:
+            metadata = dict(doc.metadata)
+            score = metadata.get("score", 0.0)
+            metadata.setdefault("ref_id", metadata.get("ref_id", doc.id))
+            metadata.setdefault("chunk_id", metadata.get("chunk_id", doc.id))
+            metadata.setdefault("paper_title", metadata.get("paper_title", ""))
+            results.append(
+                QueryResult(
+                    content=doc.page_content,
+                    score=score,
+                    metadata=metadata,
+                )
+            )
+        return results
+
+
+register_collection("search_papers", PaperCollection)

--- a/src/dreamsboard/dreamsboard/collection/web_collection.py
+++ b/src/dreamsboard/dreamsboard/collection/web_collection.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import uuid
+from typing import Dict, List, Optional, Sequence
+
+from dreamsboard.dreams.task_step_to_question_chain.searx.searx import searx_query
+from dreamsboard.vector.base import DocumentWithVSId
+from dreamsboard.vector.faiss_kb_service import FaissCollectionService
+
+from .collection import BaseCollection, QueryResult, register_collection
+
+
+class WebCollection(BaseCollection):
+    def __init__(
+        self,
+        kb_name: str,
+        embed_model: str,
+        vector_name: str,
+        device: str,
+    ) -> None:
+        self._service = FaissCollectionService(
+            kb_name=kb_name,
+            embed_model=embed_model,
+            vector_name=vector_name,
+            device=device,
+        )
+
+    def add_texts(
+        self,
+        texts: Sequence[str],
+        metadatas: Optional[Sequence[Dict[str, Any]]] = None,
+    ) -> None:
+        docs = self._build_documents_from_texts(texts, metadatas)
+        if docs:
+            self._service.do_add_doc(docs)
+
+    def _build_documents_from_texts(
+        self,
+        texts: Sequence[str],
+        metadatas: Optional[Sequence[Dict[str, Any]]],
+    ) -> List[DocumentWithVSId]:
+        metadatas = metadatas or [{}] * len(texts)
+        documents: List[DocumentWithVSId] = []
+        for text, metadata in zip(texts, metadatas):
+            metadata = dict(metadata)
+            ref_id = metadata.get("ref_id") or str(uuid.uuid4())
+            chunk_id = metadata.get("chunk_id") or ref_id
+            metadata.setdefault("paper_title", metadata.get("paper_title", metadata.get("title", "")))
+            metadata.setdefault("ref_id", ref_id)
+            metadata.setdefault("chunk_id", chunk_id)
+            documents.append(
+                DocumentWithVSId(
+                    id=str(ref_id),
+                    page_content=text,
+                    metadata=metadata,
+                )
+            )
+        return documents
+
+    def _upsert(self, docs: List[DocumentWithVSId]) -> None:
+        if not docs:
+            return
+        existing = self._service.get_doc_by_ids([doc.id for doc in docs])
+        existing_ids = {doc.id for doc in existing}
+        new_docs = [doc for doc in docs if doc.id not in existing_ids]
+        if new_docs:
+            self._service.do_add_doc(new_docs)
+
+    def query(self, query: str, top_k: int = 5) -> List[QueryResult]:
+        properties = searx_query(query, top_k)
+        docs: List[DocumentWithVSId] = []
+        for item in properties:
+            metadata = dict(item)
+            text = metadata.pop("chunk_text", "")
+            ref_id = str(metadata.get("ref_id") or uuid.uuid4())
+            chunk_id = str(metadata.get("chunk_id") or ref_id)
+            metadata.setdefault("paper_title", metadata.get("paper_title", metadata.get("title", "")))
+            metadata.setdefault("ref_id", ref_id)
+            metadata.setdefault("chunk_id", chunk_id)
+            docs.append(
+                DocumentWithVSId(
+                    id=ref_id,
+                    page_content=text,
+                    metadata=metadata,
+                )
+            )
+        self._upsert(docs)
+        documents = self._service.do_search(query=query, top_k=top_k)
+        results: List[QueryResult] = []
+        for doc in documents:
+            metadata = dict(doc.metadata)
+            score = metadata.get("score", 0.0)
+            metadata.setdefault("ref_id", metadata.get("ref_id", doc.id))
+            metadata.setdefault("chunk_id", metadata.get("chunk_id", doc.id))
+            metadata.setdefault("paper_title", metadata.get("paper_title", metadata.get("title", "")))
+            results.append(
+                QueryResult(
+                    content=doc.page_content,
+                    score=score,
+                    metadata=metadata,
+                )
+            )
+        return results
+
+
+register_collection("web_search", WebCollection)

--- a/src/dreamsboard/dreamsboard/dreams/task_step_to_question_chain/base.py
+++ b/src/dreamsboard/dreamsboard/dreams/task_step_to_question_chain/base.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import logging
 import os
 import re
-import threading
 from abc import ABC
-from typing import Dict, List
+from typing import List
 
 import pandas as pd
 from langchain.chains import SequentialChain
@@ -19,24 +18,17 @@ from langchain_core.prompts import PromptTemplate
 from langchain_core.runnables import Runnable, RunnableLambda, RunnableParallel
 from sentence_transformers import CrossEncoder
 
-from dreamsboard.common.callback import event_manager
 from dreamsboard.document_loaders import KorLoader
 from dreamsboard.document_loaders.protocol.ner_protocol import TaskStepNode
 from dreamsboard.dreams.task_step_to_question_chain.prompts import (
     CONVERT_TASK_STEP_TO_QUESTION_PROMPT_TEMPLATE,
     TASK_STEP_QUESTION_TO_GRAPHQL_PROMPT_TEMPLATE,
 )
-from dreamsboard.dreams.task_step_to_question_chain.searx.searx import searx_query
-from dreamsboard.dreams.task_step_to_question_chain.weaviate.prepare_load import (
-    exe_query,
-    get_query_hash,
-)
+from dreamsboard.collection import BaseCollection
 from dreamsboard.engine.entity.task_step.task_step import TaskStepContext
 from dreamsboard.engine.storage.storage_context import BaseTaskStepStore
 from dreamsboard.engine.storage.task_step_store.types import DEFAULT_PERSIST_FNAME
 from dreamsboard.engine.utils import concat_dirs
-from dreamsboard.vector.base import CollectionService, DocumentWithVSId
-import time
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
@@ -65,7 +57,7 @@ class TaskStepToQuestionChain(ABC):
     task_step_to_question_chain: Chain
     task_step_store: BaseTaskStepStore
     task_step_question_to_graphql_chain: Chain
-    collection: CollectionService
+    collection: BaseCollection
     cross_encoder: CrossEncoder
     data_base: str
 
@@ -76,7 +68,7 @@ class TaskStepToQuestionChain(ABC):
         task_step_store: BaseTaskStepStore,
         task_step_to_question_chain: Chain,
         task_step_question_to_graphql_chain: Chain,
-        collection: CollectionService,
+        collection: BaseCollection,
         cross_encoder: CrossEncoder,
         data_base: str,
     ):
@@ -96,7 +88,7 @@ class TaskStepToQuestionChain(ABC):
         start_task_context: str,
         llm_runable: Runnable[LanguageModelInput, BaseMessage],
         task_step_store: BaseTaskStepStore,
-        collection: CollectionService,
+        collection: BaseCollection,
         cross_encoder: CrossEncoder,
         data_base: str = "search_papers",
     ) -> TaskStepToQuestionChain:
@@ -194,55 +186,6 @@ class TaskStepToQuestionChain(ABC):
         )
         self.task_step_store.persist(persist_path=task_step_store_path)
 
-    @staticmethod
-    def _into_database_query(callback, resource_id, **kwargs) -> None:
-        """
-        插入数据到向量数据库,检查唯一
-        :param union_id_key:  唯一标识
-        :param page_content_key:  数据列表
-        :param properties_list:  数据列表
-        :return: None
-        """
-
-        union_ids = [
-            str(item.get(kwargs.get("union_id_key")))
-            for item in kwargs.get("properties_list")
-        ]
-        if len(union_ids) == 0:
-            callback([])
-            return
-        if kwargs.get("properties_list") == 0:
-            callback([])
-            return
-
-        response = kwargs.get("collection").get_doc_by_ids(ids=union_ids)
-
-        exist_ids = [o.metadata[kwargs.get("union_id_key")] for o in response]
-
-        docs = []
-        for item in kwargs.get("properties_list"):
-            metadata = {
-                key: value
-                for key, value in item.items()
-                if key != kwargs.get("page_content_key")
-            }
-            if item.get(kwargs.get("union_id_key")) not in exist_ids:
-                doc = DocumentWithVSId(
-                    id=item.get(kwargs.get("union_id_key")),
-                    page_content=item.get(kwargs.get("page_content_key")),
-                    metadata=metadata,
-                )
-                docs.append(doc)
-
-        kwargs.get("collection").do_add_doc(docs)
-
-        kwargs.get("collection").save_vector_store()
-        # 召回
-        response = kwargs.get("collection").do_search(
-            query=kwargs.get("task_step_question"), top_k=10, score_threshold=0.6
-        )
-        callback(response)
-
     def invoke_task_step_question_context(self, task_step_id: str) -> None:
         """
         对任务步骤进行抽取，得到任务步骤的上下文
@@ -257,67 +200,45 @@ class TaskStepToQuestionChain(ABC):
             return
 
         top_k = 4  # 可选参数，默认查询返回前 4个结果
-        if self.data_base == "search_papers":
-            properties_list = exe_query(task_step_node.task_step_question, top_k)
-        elif self.data_base == "searx":
-            properties_list = searx_query(task_step_node.task_step_question, top_k)
-
-        # 插入数据到数据库
-        owner = f"register_event thread {threading.get_native_id()}"
-        logger.info(f"owner:{owner}")
-        # 设置超时时间，例如 10 秒
-        timeout = 20
-        start_time = time.time()
-        event_id = event_manager.register_event(
-            self._into_database_query,
-            resource_id=f"resource_collection_{self.collection.kb_name}",
-            kwargs={
-                "collection": self.collection,
-                "union_id_key": "ref_id",
-                "page_content_key": "chunk_text",
-                "properties_list": properties_list,
-                "task_step_question": task_step_node.task_step_question,
-            },
+        results = self.collection.query(
+            task_step_node.task_step_question,
+            top_k=top_k,
         )
-        results = None
-        while (results is None or len(results) == 0) and (time.time() - start_time < timeout):
-            # 每次循环延时 0.5 秒
-            time.sleep(0.5)
-                    
-            results = event_manager.get_results(event_id)
-        response = results[0]
-        if len(response) == 0:
+        if not results:
             return
-        
-        chunk_texts = []
-        ref_ids = []
-        chunk_ids = []
-        paper_titles = []
-        for o in response:
-            chunk_texts.append(o.page_content)
-            ref_ids.append(o.metadata["ref_id"])
-            chunk_ids.append(o.metadata["chunk_id"])
-            paper_titles.append(o.metadata.get("paper_title", ""))
+
+        texts = [result.content for result in results]
+        metadata_list = [result.metadata for result in results]
 
         rankings = self.cross_encoder.rank(
             task_step_node.task_step_question,
-            chunk_texts,
+            texts,
             show_progress_bar=True,
             return_documents=True,
             convert_to_tensor=True,
         )
 
-        task_step_question_context = []
-        # 召回问题前3条，存入task_step_question_context
-        for i, ranking in enumerate(rankings[:3]):
+        task_step_question_context: List[TaskStepContext] = []
+        for ranking in rankings[:3]:
+            corpus_id = ranking.get("corpus_id")
+            if corpus_id is None or corpus_id >= len(metadata_list):
+                continue
+            metadata = metadata_list[corpus_id]
+            ref_id = str(metadata.get("ref_id", ""))
+            chunk_id = str(metadata.get("chunk_id", ""))
+            paper_title = str(metadata.get("paper_title", metadata.get("title", "")))
             logger.info(
-                f"ref_ids: {ref_ids[i]},chunk_ids: {chunk_ids[i]}, Score: {ranking['score']:.4f}, Text: {ranking['text']}"
+                "ref_ids: %s,chunk_ids: %s, Score: %.4f, Text: %s",
+                ref_id,
+                chunk_id,
+                ranking["score"],
+                ranking["text"],
             )
             task_step_question_context.append(
                 TaskStepContext(
-                    ref_id=str(ref_ids[i]),
-                    paper_title=str(paper_titles[i]),
-                    chunk_id=str(chunk_ids[i]),
+                    ref_id=ref_id,
+                    paper_title=paper_title,
+                    chunk_id=chunk_id,
                     score=ranking["score"],
                     text=ranking["text"],
                 )

--- a/src/dreamsboard/dreamsboard/engine/task_engine_builder/core.py
+++ b/src/dreamsboard/dreamsboard/engine/task_engine_builder/core.py
@@ -40,7 +40,7 @@ from dreamsboard.engine.storage.task_step_store.types import (
     BaseTaskStepStore,
 )
 from dreamsboard.engine.utils import concat_dirs
-from dreamsboard.vector.base import CollectionService
+from dreamsboard.collection import BaseCollection
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -73,7 +73,7 @@ class TaskEngineBuilder:
     base_path: str
     cross_encoder: CrossEncoder
     data_base: str
-    collection: CollectionService
+    collection: BaseCollection
     storage_context: StorageContext
     task_step_store: BaseTaskStepStore
     task_step_id: str
@@ -87,7 +87,7 @@ class TaskEngineBuilder:
         base_path: str,
         llm_runable: Runnable[LanguageModelInput, BaseMessage],
         cross_encoder: CrossEncoder,
-        collection: CollectionService,
+        collection: BaseCollection,
         start_task_context: str,
         task_step_store: BaseTaskStepStore,
         task_step_id: str,

--- a/src/dreamsboard/tests/test_builder_task_step/test_form_builder_unit.py
+++ b/src/dreamsboard/tests/test_builder_task_step/test_form_builder_unit.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from typing import Dict, List, Optional, Sequence
+
+import pytest
+
+
+class _DummyCrossEncoder:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def rank(self, *args, **kwargs):  # pragma: no cover - not used here
+        return []
+
+
+sys.modules.setdefault(
+    "torch", SimpleNamespace(cuda=SimpleNamespace(is_available=lambda: False))
+)
+sys.modules.setdefault(
+    "sentence_transformers", SimpleNamespace(CrossEncoder=_DummyCrossEncoder)
+)
+
+from dreamsboard.collection import BaseCollection
+from dreamsboard.dreams.builder_task_step.base import StructuredTaskStepStoryboard
+
+
+class _DummyCollection(BaseCollection):
+    def __init__(self):
+        self.queries: List[str] = []
+
+    def add_texts(
+        self,
+        texts: Sequence[str],
+        metadatas: Optional[Sequence[Dict[str, str]]] = None,
+    ) -> None:  # pragma: no cover - interface requirement
+        return None
+
+    def query(self, query: str, top_k: int = 5):
+        self.queries.append(query)
+        return []
+
+
+class _DummyTaskStepStore:
+    task_step_all: Dict[str, object] = {}
+
+    def add_task_step(self, _):  # pragma: no cover - not used in unit test
+        return None
+
+    def persist(self, persist_path: str):  # pragma: no cover - not used
+        return None
+
+
+class _DummyAemoChain:
+    def invoke_aemo_representation_context(self):
+        return {"aemo_representation_context": "context"}
+
+
+@pytest.mark.parametrize(
+    "data_base, extra_kwargs",
+    [
+        ("search_papers", {}),
+        ("web_search", {}),
+        ("local_collection", {"docs_path": "dummy"}),
+    ],
+)
+def test_form_builder_uses_collection(monkeypatch, data_base, extra_kwargs):
+    sys.modules.setdefault(
+        "torch", SimpleNamespace(cuda=SimpleNamespace(is_available=lambda: False))
+    )
+    created: Dict[str, Dict[str, object]] = {}
+
+    def fake_create(mode: str, **kwargs):
+        created[mode] = kwargs
+        return _DummyCollection()
+
+    monkeypatch.setattr(
+        "dreamsboard.dreams.builder_task_step.base.create_collection", fake_create
+    )
+    monkeypatch.setattr(
+        "dreamsboard.dreams.builder_task_step.base.AEMORepresentationChain.from_aemo_representation_chain",
+        classmethod(lambda *args, **kwargs: _DummyAemoChain()),
+    )
+    monkeypatch.setattr(
+        "dreamsboard.dreams.builder_task_step.base.CrossEncoder",
+        _DummyCrossEncoder,
+    )
+    monkeypatch.setattr(
+        "dreamsboard.dreams.builder_task_step.base.SimpleTaskStepStore.from_persist_dir",
+        classmethod(lambda cls, *_args, **_kwargs: _DummyTaskStepStore()),
+    )
+
+    builder = StructuredTaskStepStoryboard.form_builder(
+        llm_runable=None,
+        kor_dreams_task_step_llm=None,
+        start_task_context="context",
+        cross_encoder_path="cross",
+        embed_model_path="embed",
+        data_base=data_base,
+        collection_kwargs=extra_kwargs,
+    )
+
+    expected_mode = "web_search" if data_base == "searx" else data_base
+    assert expected_mode in created
+    call_kwargs = created[expected_mode]
+    assert call_kwargs["kb_name"]
+    if data_base == "local_collection":
+        assert call_kwargs["docs_path"] == "dummy"
+    assert isinstance(builder.collection, _DummyCollection)

--- a/src/dreamsboard/tests/test_collection/test_local_collection_local.py
+++ b/src/dreamsboard/tests/test_collection/test_local_collection_local.py
@@ -1,0 +1,68 @@
+from typing import List
+
+import pytest
+
+from dreamsboard.collection import create_collection
+from dreamsboard.vector.base import DocumentWithVSId
+
+
+class _DummyFaissService:
+    def __init__(self, *args, **kwargs):
+        self._docs: List[DocumentWithVSId] = []
+
+    def do_clear_vs(self):
+        self._docs.clear()
+
+    def do_add_doc(self, docs):
+        self._docs.extend(docs)
+
+    def do_search(self, query: str, top_k: int, score_threshold: float = 1):
+        results: List[DocumentWithVSId] = []
+        for doc in self._docs:
+            metadata = dict(doc.metadata)
+            metadata["score"] = metadata.get("score", 1.0)
+            results.append(
+                DocumentWithVSId(
+                    id=doc.id,
+                    page_content=doc.page_content,
+                    metadata=metadata,
+                )
+            )
+        return results[:top_k]
+
+    def get_doc_by_ids(self, ids):
+        selected = []
+        for doc in self._docs:
+            if doc.id in ids:
+                selected.append(doc)
+        return selected
+
+
+@pytest.fixture(autouse=True)
+def patch_faiss_service(monkeypatch):
+    monkeypatch.setattr(
+        "dreamsboard.collection.local_collection.FaissCollectionService",
+        _DummyFaissService,
+    )
+    yield
+
+
+def test_local_collection_from_directory(tmp_path):
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "sample.md").write_text("# Heading\n\nSome local content.", encoding="utf-8")
+
+    collection = create_collection(
+        "local_collection",
+        kb_name="kb",
+        embed_model="model",
+        vector_name="vectors",
+        device="cpu",
+        docs_path=str(docs_dir),
+        chunk_size=50,
+        chunk_overlap=0,
+    )
+    results = collection.query("local", top_k=2)
+    assert results
+    assert "local" in results[0].content.lower()
+    assert results[0].metadata["ref_id"]


### PR DESCRIPTION
## Summary
- instantiate the LocalCollection FAISS services directly in its constructor to retain the primary service attribute
- defer indexing of local documents until the collection is first used, caching configuration needed for later indexing
- ensure add_texts and query calls trigger the lazy indexing path before serving results

## Testing
- pytest src/dreamsboard/tests/test_collection/test_local_collection_local.py

------
https://chatgpt.com/codex/tasks/task_e_68dd7d54f54483279931e23919c75df4