### PR TITLE
Clarify integration ChatOpenAI configuration without mocks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Integration test environment variables
+# Copy this file to `.env` or export the variables in your shell before running
+# the integration test suite. Secrets should never be committed.
+OPENAI_API_KEY=
+CROSS_ENCODER_PATH=
+EMBED_MODEL_PATH=
+# Optional: override ChatOpenAI profile definitions used by integration tests.
+# CHAT_OPENAI_PROFILES_PATH=src/dreamsboard/tests/integration_tests/config/chat_openai_profiles.json
+# CHAT_OPENAI_PROFILES_JSON={"profiles":{}}
+# Optional: override ChatOpenAI default parameters.
+# CHAT_OPENAI_MODEL=gpt-4o-mini
+# CHAT_OPENAI_TEMPERATURE=0
+# CHAT_OPENAI_MAX_RETRIES=2
+# CHAT_OPENAI_TIMEOUT=120

--- a/src/dreamsboard/tests/README.md
+++ b/src/dreamsboard/tests/README.md
@@ -1,0 +1,78 @@
+# Dreamsboard Integration Test Guide
+
+This guide documents the environment requirements for `src/dreamsboard/tests/integration_tests` so that contributors can reliably run the suite locally and in CI. The structure mirrors the [LangChain testing requirements](https://docs.langchain.com/oss/python/contributing/code#testing-requirements) by clearly separating external dependencies, configuration, and skip logic.
+
+## 1. 外部服务 / API 要求
+
+| 服务 | 使用位置 | 关联环境变量 | 说明与策略 |
+| --- | --- | --- | --- |
+| OpenAI 兼容对话模型 | `test_aemo_representation_chain` 链构建与提示调用 | `OPENAI_API_KEY` (必需) | 若未设置则集成测试整体跳过，同时给出缺失凭据的提示信息。 |
+| Cross-Encoder 重排序模型 | 语义检索/重排序相关链 | `CROSS_ENCODER_PATH` (可选) | 支持本地权重路径或 Hugging Face 标识。缺失时依赖 `cross_encoder_path` fixture 的测试会自动 `skip`。 |
+| Embedding 模型/向量索引 | 向量检索构建流程 | `EMBED_MODEL_PATH` (可选) | 指向 FAISS/向量模型存储目录。缺失时依赖 `embed_model_path` fixture 的测试会自动 `skip`。 |
+
+若未设置必需的外部服务凭据，`pytest` 会输出 `Skipping test: Missing external API credentials.` 并自动跳过对应用例。
+
+## 2. 配置项说明
+
+- `START_TASK_CONTEXT`: 统一的任务上下文路径，位于 `src/dreamsboard/tests/integration_tests/fixtures/task_context.json`，通过 `load_start_task_context()` 读取。
+- `CHAT_OPENAI_DEFAULTS`: ChatOpenAI 客户端统一默认配置（模型、温度、超时等），详见 `src/dreamsboard/tests/integration_tests/utils/environment.py`。
+- `config/chat_openai_profiles.json`: 通过集中式配置管理所有 ChatOpenAI 运行参数，避免在测试中硬编码模型地址或网关。若需要自定义，可设置 `CHAT_OPENAI_PROFILES_PATH` 指向自定义 JSON，或通过 `CHAT_OPENAI_PROFILES_JSON` 传入 JSON 字符串。
+- `CHAT_OPENAI_MODEL`、`CHAT_OPENAI_TEMPERATURE`、`CHAT_OPENAI_MAX_RETRIES`、`CHAT_OPENAI_TIMEOUT`：用于覆盖默认的对话模型、温度、重试次数与请求超时时间，便于在不同环境下统一配置。
+- `get_env_path(name)`: 帮助函数，用于解析模型路径环境变量（如 `CROSS_ENCODER_PATH`）。
+- `require_env_path(name)`: 若对应环境变量缺失则通过 `pytest.skip` 中止当前测试，保证测试人员能够清晰获知缺失的资源。
+
+## 3. ChatOpenAI 使用规范
+
+- **版本与导入**：默认使用 `langchain_openai.ChatOpenAI` 或 `langchain_community.chat_models.ChatOpenAI`。
+- **默认配置**：`CHAT_OPENAI_DEFAULTS` 中定义，模型默认为 `gpt-4o-mini`，`temperature=0`，`max_retries=2`，`request_timeout=120s`。
+- **环境 Profile**：使用 `create_chat_openai(profile="<name>")` 调用 `config/chat_openai_profiles.json` 中定义的参数集合，例如：
+
+  ```python
+  from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
+
+  llm = create_chat_openai(profile="glm4_plus_low_temp")
+  guidance_llm = create_chat_openai(profile="glm4_plus_guidance")
+  ```
+
+  Profile 支持环境变量占位符（如 `env:OPENAI_API_BASE` 或带回退的 `env:DEEPSEEK_API_BASE||env:OPENAI_API_BASE`），缺失时会 `pytest.skip` 提示所需变量。
+- **配置来源**：所有参数来自统一的 JSON 配置文件（默认 `config/chat_openai_profiles.json`）。该文件可在本地覆写，或通过 `CHAT_OPENAI_PROFILES_JSON` 环境变量直接提供 JSON 内容。
+
+## 4. 辅助工具与共享配置
+
+- `integration_environment` fixture：在 `conftest.py` 中自动运行，确保满足环境条件或在缺少凭据时跳过测试。
+- `start_task_context_payload` fixture：加载统一的任务上下文 JSON。
+- `cross_encoder_path` fixture：解析 `CROSS_ENCODER_PATH` 并在缺失时自动跳过当前测试。
+- `embed_model_path` fixture：解析 `EMBED_MODEL_PATH` 并在缺失时自动跳过当前测试。
+- 所有工具函数位于 `src/dreamsboard/tests/integration_tests/utils/environment.py`，包含对缺失凭据的 Skip 逻辑 (`ensure_external_services_available`)。
+
+## 5. 运行流程
+
+### 本地环境
+
+1. 复制并填充 `.env.example`：
+
+   ```bash
+   cp .env.example .env
+   export $(grep -v '^#' .env | xargs)
+   ```
+
+2. 安装依赖并运行：
+
+   ```bash
+   poetry install
+   poetry run pytest src/dreamsboard/tests/integration_tests -m "not slow"
+   ```
+
+### CI 环境
+
+1. 在 CI Secrets 中配置 `OPENAI_API_KEY`、`CROSS_ENCODER_PATH`、`EMBED_MODEL_PATH`。
+2. 在流水线脚本中加载 `.env.example`，将 Secrets 写入运行环境。
+3. 运行 `poetry run pytest src/dreamsboard/tests/integration_tests`。
+4. 若 Secrets 不可用，测试会自动 Skip 并给出缺失凭据提示。
+
+## 6. 参考
+
+- LangChain 官方测试规范：确保网络依赖在凭据缺失时自动跳过。
+- `src/dreamsboard/tests/integration_tests/test_aemo_representation_chain/prompts.py`：在模块注释中记录依赖与配置策略。
+- `src/dreamsboard/tests/integration_tests/conftest.py`：集中处理 pytest 配置与环境校验逻辑。
+- `src/dreamsboard/tests/integration_tests/utils/environment.py`：环境变量与共享工具的实现。

--- a/src/dreamsboard/tests/integration_tests/config/chat_openai_profiles.json
+++ b/src/dreamsboard/tests/integration_tests/config/chat_openai_profiles.json
@@ -1,0 +1,180 @@
+{
+  "profiles": {
+    "default": {
+      "parameters": {}
+    },
+    "verbose": {
+      "inherit": "default",
+      "parameters": {
+        "verbose": true
+      }
+    },
+    "gpt4o": {
+      "inherit": "verbose",
+      "parameters": {
+        "model": "gpt-4o"
+      }
+    },
+    "gpt4o_guidance": {
+      "inherit": "gpt4o",
+      "parameters": {
+        "temperature": 0.95,
+        "top_p": 0.7
+      }
+    },
+    "deepseek_base": {
+      "parameters": {
+        "openai_api_base": "http://127.0.0.1:20000/deepseek/v1",
+        "model": "deepseek-chat",
+        "openai_api_key": "sk-c7balko7z4266rye",
+        "verbose": true
+      }
+    },
+    "deepseek_guidance": {
+      "inherit": "deepseek_base",
+      "parameters": {
+        "temperature": 0.95,
+        "top_p": 0.7
+      }
+    },
+    "deepseek_env_primary": {
+      "parameters": {
+        "openai_api_base": "env:DEEPSEEK_API_BASE||env:OPENAI_API_BASE",
+        "model": "env:DEEPSEEK_API_MODEL||env:OPENAI_MODEL_NAME",
+        "openai_api_key": "env:DEEPSEEK_API_KEY||env:OPENAI_API_KEY",
+        "verbose": true,
+        "temperature": 0.9,
+        "top_p": 0.9,
+        "max_tokens": 4000
+      }
+    },
+    "deepseek_env_secondary": {
+      "inherit": "deepseek_env_primary",
+      "parameters": {
+        "temperature": 0.1
+      }
+    },
+    "deepseek_env_longform": {
+      "inherit": "deepseek_env_primary",
+      "parameters": {
+        "max_tokens": 8192
+      }
+    },
+    "openai_builder_base": {
+      "parameters": {
+        "openai_api_base": "env:OPENAI_API_BASE",
+        "model": "env:OPENAI_MODEL_NAME",
+        "openai_api_key": "env:OPENAI_API_KEY",
+        "verbose": true,
+        "temperature": 0.1,
+        "top_p": 0.9
+      }
+    },
+    "openai_builder_guidance": {
+      "inherit": "openai_builder_base",
+      "parameters": {
+        "temperature": 0.95,
+        "top_p": 0.7
+      }
+    },
+    "glm4_gateway_guidance": {
+      "parameters": {
+        "openai_api_base": "http://0.0.0.0:8000/v1",
+        "model": "glm-4",
+        "openai_api_key": "glm-4",
+        "verbose": true,
+        "temperature": 0.95,
+        "top_p": 0.7
+      }
+    },
+    "glm4_remote_guidance": {
+      "parameters": {
+        "openai_api_base": "https://open.bigmodel.cn/api/paas/v4",
+        "model": "glm-4",
+        "openai_api_key": "testkey",
+        "verbose": true,
+        "temperature": 0.95,
+        "top_p": 0.7
+      }
+    },
+    "glm4_remote_guidance_slash": {
+      "parameters": {
+        "openai_api_base": "https://open.bigmodel.cn/api/paas/v4/",
+        "model": "glm-4",
+        "openai_api_key": "testkey",
+        "verbose": true,
+        "temperature": 0.95,
+        "top_p": 0.7
+      }
+    },
+    "glm4_remote_low_temp": {
+      "parameters": {
+        "openai_api_base": "https://open.bigmodel.cn/api/paas/v4",
+        "model": "glm-4",
+        "openai_api_key": "testkey",
+        "verbose": true,
+        "temperature": 0.1,
+        "top_p": 0.9
+      }
+    },
+    "glm4_local_verbose": {
+      "parameters": {
+        "openai_api_base": "http://127.0.0.1:30000/v1",
+        "model": "glm-4",
+        "openai_api_key": "glm-4",
+        "verbose": true
+      }
+    },
+    "glm4_local_low_temp": {
+      "inherit": "glm4_local_verbose",
+      "parameters": {
+        "temperature": 0.1,
+        "top_p": 0.9
+      }
+    },
+    "glm4_local_guidance": {
+      "inherit": "glm4_local_verbose",
+      "parameters": {
+        "temperature": 0.95,
+        "top_p": 0.7
+      }
+    },
+    "glm3_local_guidance": {
+      "parameters": {
+        "openai_api_base": "http://127.0.0.1:30000/v1",
+        "model": "glm-3-turbo",
+        "openai_api_key": "glm-4",
+        "verbose": true,
+        "temperature": 0.95,
+        "top_p": 0.7
+      }
+    },
+    "glm4_airx_guidance": {
+      "parameters": {
+        "openai_api_base": "https://open.bigmodel.cn/api/paas/v4/",
+        "model": "glm-4-airx",
+        "openai_api_key": "12",
+        "verbose": true,
+        "temperature": 0.95,
+        "top_p": 0.7
+      }
+    },
+    "glm4_plus_low_temp": {
+      "parameters": {
+        "openai_api_base": "https://open.bigmodel.cn/api/paas/v4",
+        "model": "glm-4-plus",
+        "openai_api_key": "testkey",
+        "verbose": true,
+        "temperature": 0.1,
+        "top_p": 0.9
+      }
+    },
+    "glm4_plus_guidance": {
+      "inherit": "glm4_plus_low_temp",
+      "parameters": {
+        "temperature": 0.95,
+        "top_p": 0.7
+      }
+    }
+  }
+}

--- a/src/dreamsboard/tests/integration_tests/conftest.py
+++ b/src/dreamsboard/tests/integration_tests/conftest.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+"""Integration test fixtures for `dreamsboard` suites.
+
+The integration tests require external API access. Before running ensure the
+following environment variables are configured:
+
+* ``OPENAI_API_KEY``
+* ``CROSS_ENCODER_PATH``
+* ``EMBED_MODEL_PATH``
+"""
+
+from typing import Any, Callable, Dict
+
+import pytest
+
+from .utils.environment import (
+    START_TASK_CONTEXT,
+    ensure_external_services_available,
+    get_chat_openai_profile,
+    load_start_task_context,
+    resolve_chat_openai_class,
+    require_env_path,
+)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def integration_environment() -> None:
+    """Validate integration environment variables before running tests."""
+
+    ensure_external_services_available()
+
+
+@pytest.fixture(scope="session")
+def chat_openai_defaults() -> Dict[str, Any]:
+    """Expose the canonical ChatOpenAI configuration for the tests."""
+
+    return get_chat_openai_profile()
+
+
+@pytest.fixture(scope="session")
+def start_task_context_payload() -> Dict[str, Any]:
+    """Load the shared start task context file used by integration tests."""
+
+    return load_start_task_context()
+
+
+@pytest.fixture(scope="session")
+def start_task_context_path() -> str:
+    """Return the path to the shared task context JSON file."""
+
+    return str(START_TASK_CONTEXT)
+
+
+@pytest.fixture(scope="session")
+def start_task_context(start_task_context_payload: Dict[str, Any]) -> str:
+    """Expose the canonical start task context string."""
+
+    return start_task_context_payload["start_task_context"]
+
+
+@pytest.fixture(scope="session")
+def chat_openai_class(integration_environment: None):
+    """Resolve the ChatOpenAI-compatible class for integration tests."""
+
+    chat_class = resolve_chat_openai_class()
+
+    try:  # pragma: no cover - optional dependency alignment
+        import langchain_community.chat_models as community_models
+
+        community_models.ChatOpenAI = chat_class  # type: ignore[attr-defined]
+    except ImportError:
+        pass
+
+    try:  # pragma: no cover - optional dependency alignment
+        import langchain_openai as openai_module
+
+        openai_module.ChatOpenAI = chat_class  # type: ignore[attr-defined]
+    except ImportError:
+        pass
+
+    return chat_class
+
+
+@pytest.fixture(scope="session")
+def chat_openai_factory(
+    chat_openai_class,
+    chat_openai_defaults: Dict[str, Any],
+) -> Callable[..., Any]:
+    """Return a factory that instantiates ChatOpenAI-compatible clients."""
+
+    def _factory(profile: str = "default", **overrides: Any) -> Any:
+        if profile == "default":
+            params = {**chat_openai_defaults}
+        else:
+            params = get_chat_openai_profile(profile)
+        params.update(overrides)
+        params = {key: value for key, value in params.items() if value is not None}
+        return chat_openai_class(**params)
+
+    return _factory
+
+
+@pytest.fixture
+def chat_openai(chat_openai_factory: Callable[..., Any]) -> Any:
+    """Provide a default ChatOpenAI-compatible instance."""
+
+    return chat_openai_factory()
+
+
+@pytest.fixture(scope="session")
+def cross_encoder_path() -> str:
+    """Return the configured cross-encoder model path or skip if missing."""
+
+    return str(require_env_path("CROSS_ENCODER_PATH"))
+
+
+@pytest.fixture(scope="session")
+def embed_model_path() -> str:
+    """Return the configured embedding model path or skip if missing."""
+
+    return str(require_env_path("EMBED_MODEL_PATH"))

--- a/src/dreamsboard/tests/integration_tests/fixtures/task_context.json
+++ b/src/dreamsboard/tests/integration_tests/fixtures/task_context.json
@@ -1,0 +1,8 @@
+{
+  "start_task_context": "有哪些方法可以提升大模型的规划能力，各自优劣是什么？",
+  "description": "Shared task context used by integration tests to ensure deterministic prompts.",
+  "metadata": {
+    "source": "integration_tests/fixtures/task_context.json",
+    "updated_at": "2024-06-01T00:00:00Z"
+  }
+}

--- a/src/dreamsboard/tests/integration_tests/kor/test_kor.py
+++ b/src/dreamsboard/tests/integration_tests/kor/test_kor.py
@@ -1,4 +1,4 @@
-from langchain_openai import ChatOpenAI
+from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
 from dreamsboard.document_loaders import KorLoader
 from dreamsboard.document_loaders.protocol.ner_protocol import DreamsStepInfo
@@ -16,13 +16,7 @@ def test_kor_glm_3():
     for val in dreams_analysis_store.analysis_all.values():
         dreams_guidance_context = val.dreams_guidance_context
         dreams_personality_context = val.dreams_personality_context
-    guidance_llm = ChatOpenAI(
-        openai_api_base="http://0.0.0.0:8000/v1",
-        model="glm-4",
-        verbose=True,
-        temperature=0.95,
-        top_p=0.70,
-    )
+    guidance_llm = create_chat_openai(profile="glm4_gateway_guidance")
     kor_dreams_guidance_chain = KorLoader.form_kor_dreams_guidance_builder(
         llm_runable=guidance_llm
     )
@@ -53,13 +47,7 @@ def test_kor_glm_4():
     for val in dreams_analysis_store.analysis_all.values():
         dreams_guidance_context = val.dreams_guidance_context
         dreams_personality_context = val.dreams_personality_context
-    guidance_llm = ChatOpenAI(
-        openai_api_base="https://open.bigmodel.cn/api/paas/v4/",
-        model="glm-4",
-        verbose=True,
-        temperature=0.95,
-        top_p=0.70,
-    )
+    guidance_llm = create_chat_openai(profile="glm4_remote_guidance_slash")
     kor_dreams_guidance_chain = KorLoader.form_kor_dreams_guidance_builder(
         llm_runable=guidance_llm
     )

--- a/src/dreamsboard/tests/integration_tests/story_board_dreams_generation_chain.py
+++ b/src/dreamsboard/tests/integration_tests/story_board_dreams_generation_chain.py
@@ -1,7 +1,8 @@
 import logging
 
 import langchain
-from langchain_community.chat_models import ChatOpenAI
+
+from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
 from dreamsboard.dreams.dreams_personality_chain.base import (
     StoryBoardDreamsGenerationChain,
@@ -26,7 +27,7 @@ def test_story_board_dreams_generation_chain():
     # here we are configuring the wandb project name
     # os.environ["WANDB_PROJECT"] = "StoryBoardDreamsGenerationChain"
     # os.environ["WANDB_API_KEY"] = "key"
-    llm = ChatOpenAI(verbose=True)
+    llm = create_chat_openai(profile="verbose")
 
     dreams_generation_chain = StoryBoardDreamsGenerationChain.from_dreams_personality_chain(
         llm_runable=llm,

--- a/src/dreamsboard/tests/integration_tests/test_aemo_representation_chain/prompts.py
+++ b/src/dreamsboard/tests/integration_tests/test_aemo_representation_chain/prompts.py
@@ -1,5 +1,14 @@
-"""
+"""Integration Test Environment:
+Requires external API access.
+Set the following environment variables before running:
+  - OPENAI_API_KEY
+  - CROSS_ENCODER_PATH
+  - EMBED_MODEL_PATH
 
+Start task context payloads are loaded through the shared
+`start_task_context_payload` fixture, while any cross-encoder or embedding
+artifacts should be wired via the `cross_encoder_path` and `embed_model_path`
+fixtures respectively.
 """
 
 # 00-判断情感表征是否符合.txt

--- a/src/dreamsboard/tests/integration_tests/test_aemo_representation_chain/test_aemo_representation_chain.py
+++ b/src/dreamsboard/tests/integration_tests/test_aemo_representation_chain/test_aemo_representation_chain.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 
-from langchain_community.chat_models import ChatOpenAI
+from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
 from dreamsboard.dreams.aemo_representation_chain.base import AEMORepresentationChain
 from dreamsboard.engine.entity.task_step.task_step import TaskStepNode
@@ -27,18 +27,11 @@ logger.addHandler(handler)
 """
 
 
-def test_aemo_representation_chain_context():
-    llm = ChatOpenAI(
-        openai_api_base="https://open.bigmodel.cn/api/paas/v4",
-        model="glm-4-plus",
-        openai_api_key="testkey",
-        verbose=True,
-        temperature=0.1,
-        top_p=0.9,
-    )
+def test_aemo_representation_chain_context(start_task_context: str):
+    llm = create_chat_openai(profile="glm4_plus_low_temp")
     aemo_representation_chain = AEMORepresentationChain.from_aemo_representation_chain(
         llm_runable=llm,
-        start_task_context="有哪些方法可以提升大模型的规划能力，各自优劣是什么？",
+        start_task_context=start_task_context,
     )
 
     result = aemo_representation_chain.invoke_aemo_representation_context()
@@ -47,15 +40,8 @@ def test_aemo_representation_chain_context():
     assert result.get("aemo_representation_context") is not None
 
 
-def test_aemo_representation_chain_custom_prompt():
-    llm = ChatOpenAI(
-        openai_api_base="https://open.bigmodel.cn/api/paas/v4",
-        model="glm-4-plus",
-        openai_api_key="testkey",
-        verbose=True,
-        temperature=0.1,
-        top_p=0.9,
-    )
+def test_aemo_representation_chain_custom_prompt(start_task_context: str):
+    llm = create_chat_openai(profile="glm4_plus_low_temp")
     from tests.integration_tests.test_aemo_representation_chain.prompts import (
         AEMO_REPRESENTATION_PROMPT_TEMPLATE as AEMO_REPRESENTATION_PROMPT_TEMPLATE_TEST,
     )
@@ -65,7 +51,7 @@ def test_aemo_representation_chain_custom_prompt():
     ] = AEMO_REPRESENTATION_PROMPT_TEMPLATE_TEST
     aemo_representation_chain = AEMORepresentationChain.from_aemo_representation_chain(
         llm_runable=llm,
-        start_task_context="有哪些方法可以提升大模型的规划能力，各自优劣是什么？",
+        start_task_context=start_task_context,
     )
 
     result = aemo_representation_chain.invoke_aemo_representation_context()
@@ -74,23 +60,9 @@ def test_aemo_representation_chain_custom_prompt():
     assert result.get("aemo_representation_context") is not None
 
 
-def test_aemo_representation_chain_task_step():
-    llm = ChatOpenAI(
-        openai_api_base="https://open.bigmodel.cn/api/paas/v4",
-        model="glm-4-plus",
-        openai_api_key="testkey",
-        verbose=True,
-        temperature=0.1,
-        top_p=0.9,
-    )
-    kor_dreams_task_step_llm = ChatOpenAI(
-        openai_api_base="https://open.bigmodel.cn/api/paas/v4",
-        model="glm-4-plus",
-        openai_api_key="testkey",
-        verbose=True,
-        temperature=0.95,
-        top_p=0.70,
-    )
+def test_aemo_representation_chain_task_step(start_task_context: str):
+    llm = create_chat_openai(profile="glm4_plus_low_temp")
+    kor_dreams_task_step_llm = create_chat_openai(profile="glm4_plus_guidance")
     from tests.integration_tests.test_aemo_representation_chain.prompts import (
         AEMO_REPRESENTATION_PROMPT_TEMPLATE as AEMO_REPRESENTATION_PROMPT_TEMPLATE_TEST,
     )
@@ -100,7 +72,7 @@ def test_aemo_representation_chain_task_step():
     ] = AEMO_REPRESENTATION_PROMPT_TEMPLATE_TEST
     aemo_representation_chain = AEMORepresentationChain.from_aemo_representation_chain(
         llm_runable=llm,
-        start_task_context="有哪些方法可以提升大模型的规划能力，各自优劣是什么？",
+        start_task_context=start_task_context,
         kor_dreams_task_step_llm=kor_dreams_task_step_llm,
     )
 
@@ -117,23 +89,9 @@ def test_aemo_representation_chain_task_step():
     assert len(task_step_iter) > 0
 
 
-def test_aemo_representation_chain_task_step_store():
-    llm = ChatOpenAI(
-        openai_api_base="https://open.bigmodel.cn/api/paas/v4",
-        model="glm-4-plus",
-        openai_api_key="testkey",
-        verbose=True,
-        temperature=0.1,
-        top_p=0.9,
-    )
-    kor_dreams_task_step_llm = ChatOpenAI(
-        openai_api_base="https://open.bigmodel.cn/api/paas/v4",
-        model="glm-4-plus",
-        openai_api_key="testkey",
-        verbose=True,
-        temperature=0.95,
-        top_p=0.70,
-    )
+def test_aemo_representation_chain_task_step_store(start_task_context: str):
+    llm = create_chat_openai(profile="glm4_plus_low_temp")
+    kor_dreams_task_step_llm = create_chat_openai(profile="glm4_plus_guidance")
     from tests.integration_tests.test_aemo_representation_chain.prompts import (
         AEMO_REPRESENTATION_PROMPT_TEMPLATE as AEMO_REPRESENTATION_PROMPT_TEMPLATE_TEST,
     )
@@ -143,7 +101,7 @@ def test_aemo_representation_chain_task_step_store():
     ] = AEMO_REPRESENTATION_PROMPT_TEMPLATE_TEST
     aemo_representation_chain = AEMORepresentationChain.from_aemo_representation_chain(
         llm_runable=llm,
-        start_task_context="有哪些方法可以提升大模型的规划能力，各自优劣是什么？",
+        start_task_context=start_task_context,
         kor_dreams_task_step_llm=kor_dreams_task_step_llm,
     )
 

--- a/src/dreamsboard/tests/integration_tests/test_batch_extract/test_batch_extract.py
+++ b/src/dreamsboard/tests/integration_tests/test_batch_extract/test_batch_extract.py
@@ -7,7 +7,6 @@ import time
 from pathlib import Path
 
 import langchain
-from langchain_community.chat_models import ChatOpenAI
 from tqdm import tqdm
 
 from dreamsboard.document_loaders import StructuredStoryboardCSVBuilder, batch, load_csv
@@ -37,6 +36,8 @@ handler.setLevel(logging.DEBUG)
 logger.addHandler(handler)
 from langchain.callbacks import wandb_tracing_enabled
 
+from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
+
 
 def check_and_convert_special_characters(text):
     # 将除了中文之外的所有字符转换成\U
@@ -55,12 +56,7 @@ def test_batch_extract(setup_log) -> None:
             ds_path.mkdir()
         txt_files = load_csv(data_folder)
         logger.info("获取数据，成功{}".format(len(txt_files)))
-        llm = ChatOpenAI(
-            openai_api_base="http://127.0.0.1:20000/deepseek/v1",
-            model="deepseek-chat",
-            openai_api_key="sk-c7balko7z4266rye",
-            verbose=True,
-        )
+        llm = create_chat_openai(profile="deepseek_base")
 
         # guidance_llm = ChatOpenAI(
         #     openai_api_base='http://127.0.0.1:30000/v1',
@@ -70,22 +66,8 @@ def test_batch_extract(setup_log) -> None:
         #     temperature=0.1,
         #     top_p=0.9,
         # )
-        guidance_llm = ChatOpenAI(
-            openai_api_base="http://127.0.0.1:20000/deepseek/v1",
-            model="deepseek-chat",
-            openai_api_key="sk-c7balko7z4266rye",
-            verbose=True,
-            temperature=0.95,
-            top_p=0.70,
-        )
-        personality_llm = ChatOpenAI(
-            openai_api_base="http://127.0.0.1:20000/deepseek/v1",
-            model="deepseek-chat",
-            openai_api_key="sk-c7balko7z4266rye",
-            verbose=True,
-            temperature=0.95,
-            top_p=0.70,
-        )
+        guidance_llm = create_chat_openai(profile="deepseek_guidance")
+        personality_llm = create_chat_openai(profile="deepseek_guidance")
         batch_len = 10
 
         # 对每一个文件进行操作

--- a/src/dreamsboard/tests/integration_tests/test_builder_task_step/test_builder_task_step.py
+++ b/src/dreamsboard/tests/integration_tests/test_builder_task_step/test_builder_task_step.py
@@ -3,8 +3,6 @@ import multiprocessing
 import os
 import queue
 
-from langchain_community.chat_models import ChatOpenAI
-
 from dreamsboard.common import _get_assistants_tool
 from dreamsboard.common.try_parse_json_object import try_parse_json_object
 from dreamsboard.dreams.builder_task_step.base import StructuredTaskStepStoryboard
@@ -24,6 +22,8 @@ from langchain_community.document_loaders import UnstructuredPDFLoader
 from dreamsboard.engine.task_engine_builder.core import TaskEngineBuilder
 from dreamsboard.engine.utils import concat_dirs
 from dreamsboard.common.callback import process_registry
+
+from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -50,25 +50,13 @@ logger.addHandler(handler)
 """
 
 
-def test_builder_task_step():
-    llm = ChatOpenAI(
-        openai_api_base=os.environ.get("API_BASE"),
-        model=os.environ.get("API_MODEL"),
-        openai_api_key=os.environ.get("API_KEY"),
-        verbose=True,
-        temperature=0.1,
-        top_p=0.9,
-    )
-    kor_dreams_task_step_llm = ChatOpenAI(
-        openai_api_base=os.environ.get("API_BASE"),
-        model=os.environ.get("API_MODEL"),
-        openai_api_key=os.environ.get("API_KEY"),
-        verbose=True,
-        temperature=0.95,
-        top_p=0.70,
-    )
+def test_builder_task_step(
+    cross_encoder_path: str, embed_model_path: str
+):
+    llm = create_chat_openai(profile="openai_builder_base")
+    kor_dreams_task_step_llm = create_chat_openai(profile="openai_builder_guidance")
 
-    if "glm" in os.environ.get("API_MODEL"):
+    if "glm" in (os.environ.get("OPENAI_MODEL_NAME") or ""):
         tools = [
             {
                 "type": "web_search",
@@ -112,10 +100,6 @@ def test_builder_task_step():
     os.environ["EDREAMS_PERSONALITY_TEMPLATE"] = EDREAMS_PERSONALITY_TEMPLATE_TEST
     os.environ["DREAMS_GEN_TEMPLATE"] = DREAMS_GEN_TEMPLATE_TEST
 
-    cross_encoder_path = (
-        "/media/checkpoint/jina-reranker-v2-base-multilingual"
-    )
-    embed_model_path = "/media/checkpoint/m3e-base"
     start_task_context = "什么是损失函数？"
     builder = StructuredTaskStepStoryboard.form_builder(
         llm_runable=llm_with_tools,
@@ -133,25 +117,13 @@ def test_builder_task_step():
     assert builder.base_path == f"./{get_query_hash(start_task_context)}/"
 
 
-def test_builder_task_step_answer():
-    llm = ChatOpenAI(
-        openai_api_base=os.environ.get("API_BASE"),
-        model=os.environ.get("API_MODEL"),
-        openai_api_key=os.environ.get("API_KEY"),
-        verbose=True,
-        temperature=0.1,
-        top_p=0.9,
-    )
-    kor_dreams_task_step_llm = ChatOpenAI(
-        openai_api_base=os.environ.get("API_BASE"),
-        model=os.environ.get("API_MODEL"),
-        openai_api_key=os.environ.get("API_KEY"),
-        verbose=True,
-        temperature=0.95,
-        top_p=0.70,
-    )
+def test_builder_task_step_answer(
+    cross_encoder_path: str, embed_model_path: str
+):
+    llm = create_chat_openai(profile="openai_builder_base")
+    kor_dreams_task_step_llm = create_chat_openai(profile="openai_builder_guidance")
 
-    if "glm" in os.environ.get("API_MODEL"):
+    if "glm" in (os.environ.get("OPENAI_MODEL_NAME") or ""):
         tools = [
             {
                 "type": "web_search",
@@ -196,10 +168,6 @@ def test_builder_task_step_answer():
     os.environ["DREAMS_GEN_TEMPLATE"] = DREAMS_GEN_TEMPLATE_TEST
 
     # 存储
-    cross_encoder_path = (
-        "/media/checkpoint/jina-reranker-v2-base-multilingual"
-    )
-    embed_model_path = "/media/checkpoint/m3e-base"
     start_task_context = "什么是损失函数？"
     builder = StructuredTaskStepStoryboard.form_builder(
         llm_runable=llm_with_tools,
@@ -209,8 +177,7 @@ def test_builder_task_step_answer():
         embed_model_path=embed_model_path,
     )
     # 初始化任务引擎
-    os.environ["OPENAI_API_KEY"] = os.environ.get("ZHIPUAI_API_KEY")
-    os.environ["OPENAI_API_BASE"] = "https://open.bigmodel.cn/api/paas/v4"
+    os.environ.setdefault("OPENAI_API_BASE", "https://open.bigmodel.cn/api/paas/v4")
     task_engine_builder = builder.loader_task_step_iter_builder(allow_init=False)
     task_step_store = builder.task_step_store
     while not task_engine_builder.empty():
@@ -240,25 +207,13 @@ def test_json_parse():
     refined_answer = RefineResponse.model_validate_json(json_text)
 
 
-def test_builder_task_step_mctsr():
-    llm = ChatOpenAI(
-        openai_api_base=os.environ.get("API_BASE"),
-        model=os.environ.get("API_MODEL"),
-        openai_api_key=os.environ.get("API_KEY"),
-        verbose=True,
-        temperature=0.1,
-        top_p=0.9,
-    )
-    kor_dreams_task_step_llm = ChatOpenAI(
-        openai_api_base=os.environ.get("API_BASE"),
-        model=os.environ.get("API_MODEL"),
-        openai_api_key=os.environ.get("API_KEY"),
-        verbose=True,
-        temperature=0.95,
-        top_p=0.70,
-    )
+def test_builder_task_step_mctsr(
+    cross_encoder_path: str, embed_model_path: str
+):
+    llm = create_chat_openai(profile="openai_builder_base")
+    kor_dreams_task_step_llm = create_chat_openai(profile="openai_builder_guidance")
 
-    if "glm" in os.environ.get("API_MODEL"):
+    if "glm" in (os.environ.get("OPENAI_MODEL_NAME") or ""):
         tools = [
             {
                 "type": "web_search",
@@ -302,11 +257,6 @@ def test_builder_task_step_mctsr():
     os.environ["EDREAMS_PERSONALITY_TEMPLATE"] = EDREAMS_PERSONALITY_TEMPLATE_TEST
     os.environ["DREAMS_GEN_TEMPLATE"] = DREAMS_GEN_TEMPLATE_TEST
 
-    # 存储
-    cross_encoder_path = (
-        "/media/checkpoint/jina-reranker-v2-base-multilingual"
-    )
-    embed_model_path = "/media/checkpoint/m3e-base"
     start_task_context = "什么是损失函数？"
     builder = StructuredTaskStepStoryboard.form_builder(
         llm_runable=llm_with_tools,
@@ -373,27 +323,13 @@ def test_task_step_md():
     print(md_text.text)
 
 
-def test_builder_task_step_mctsr_threads(setup_log):
+def test_builder_task_step_mctsr_threads(
+    setup_log, cross_encoder_path: str, embed_model_path: str
+):
     import threading
-    llm = ChatOpenAI(
-        openai_api_base=os.environ.get("DEEPSEEK_API_BASE"),
-        model=os.environ.get("DEEPSEEK_API_MODEL"),
-        openai_api_key=os.environ.get("DEEPSEEK_API_KEY"),
-        verbose=True,
-        temperature=0.9,
-        top_p=0.9,
-        max_tokens=4000,
-    )
+    llm = create_chat_openai(profile="deepseek_env_primary")
 
-    guiji_llm = ChatOpenAI(
-        openai_api_base=os.environ.get("DEEPSEEK_API_BASE"),
-        model=os.environ.get("DEEPSEEK_API_MODEL"),
-        openai_api_key=os.environ.get("DEEPSEEK_API_KEY"),
-        verbose=True,
-        temperature=0.1,
-        top_p=0.9,
-        max_tokens=4000,
-    )
+    guiji_llm = create_chat_openai(profile="deepseek_env_secondary")
     llm_with_tools = llm
     kor_dreams_task_step_llm_with_tools = guiji_llm
 
@@ -427,11 +363,6 @@ def test_builder_task_step_mctsr_threads(setup_log):
     os.environ["EDREAMS_PERSONALITY_TEMPLATE"] = EDREAMS_PERSONALITY_TEMPLATE_TEST
     os.environ["DREAMS_GEN_TEMPLATE"] = DREAMS_GEN_TEMPLATE_TEST
 
-    # 存储
-    cross_encoder_path = (
-        "/media/checkpoint/jina-reranker-v2-base-multilingual"
-    )
-    embed_model_path = "/media/checkpoint/m3e-base"
     start_task_context = "在 4-bit 量化后进行微调训练时，如果 cross-entropy loss 在高 step 下仍然波动较大、难以稳定收敛，这种现象是由于 batch 数据分布差异造成的，还是和特殊参数（如 LoRA / WCT / L4Q 的量化感知参数）无法充分拟合有关？针对 L4Q 这类方法，文中是否有对收敛稳定性的分析？"
     builder = StructuredTaskStepStoryboard.form_builder(
         llm_runable=llm,
@@ -608,15 +539,7 @@ def test_prompt():
     ),
     )
 
-    llm_runable = ChatOpenAI(
-        openai_api_base=os.environ.get("DEEPSEEK_API_BASE"),
-        model=os.environ.get("DEEPSEEK_API_MODEL"),
-        openai_api_key=os.environ.get("DEEPSEEK_API_KEY"),
-        verbose=True,
-        temperature=0.9,
-        top_p=0.9,
-        max_tokens=8192,
-    )
+    llm_runable = create_chat_openai(profile="deepseek_env_longform")
 
     aemo_representation_chain = prompt_template1 | llm_runable | StrOutputParser()
 

--- a/src/dreamsboard/tests/integration_tests/test_collection/test_collection.py
+++ b/src/dreamsboard/tests/integration_tests/test_collection/test_collection.py
@@ -53,11 +53,19 @@ def _into_database_query(callback, resource_id, **kwargs) -> None:
         ("vs5", 1, "title5", "link5", "engine5", "category5", "chunk_text5"),
     ],
 )
-def test_faiss_collection_insert(setup_log, ref_id, chunk_id, title, link, engines, category, chunk_text):
+def test_faiss_collection_insert(
+    setup_log,
+    embed_model_path: str,
+    ref_id,
+    chunk_id,
+    title,
+    link,
+    engines,
+    category,
+    chunk_text,
+):
 
     collection_id = get_query_hash("start_task_context")
-    embed_model_path = "D:/model/m3e-base"
-
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
     collection = FaissCollectionService(
         kb_name=collection_id,

--- a/src/dreamsboard/tests/integration_tests/test_collection/test_loader_into_database.py
+++ b/src/dreamsboard/tests/integration_tests/test_collection/test_loader_into_database.py
@@ -48,7 +48,7 @@ def _into_database_query(callback, resource_id, **kwargs) -> None:
     callback(doc_infos)
 
 
-def test_loader_into_database():
+def test_loader_into_database(embed_model_path: str):
     loader = DirectoryLoader('/mnt/ceph/develop/jiawei/InterpretationoDreams/监管',
                              glob="**/*.md",
                              loader_cls=TextLoader,
@@ -77,7 +77,6 @@ def test_loader_into_database():
             all_chunks.extend(chunks)
 
     collection_id = get_query_hash("test_loader_into_database")
-    embed_model_path = "/mnt/ceph/develop/jiawei/model_checkpoint/m3e-base"
 
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
     collection = FaissCollectionService(

--- a/src/dreamsboard/tests/integration_tests/test_collection/test_query_database.py
+++ b/src/dreamsboard/tests/integration_tests/test_collection/test_query_database.py
@@ -20,10 +20,9 @@ from dreamsboard.common.callback import (event_manager)
 logger = logging.getLogger(__name__)
 
  
-def test_query_database():
-    
+def test_query_database(embed_model_path: str):
+
     collection_id = get_query_hash("test_loader_into_database")
-    embed_model_path = "/mnt/ceph/develop/jiawei/model_checkpoint/m3e-base"
 
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
     collection = FaissCollectionService(

--- a/src/dreamsboard/tests/integration_tests/test_engine.py
+++ b/src/dreamsboard/tests/integration_tests/test_engine.py
@@ -8,7 +8,8 @@ from langchain_community.adapters.openai import (
     convert_dict_to_message,
     convert_message_to_dict,
 )
-from langchain_community.chat_models import ChatOpenAI
+
+from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
 from dreamsboard.engine.engine_builder import CodeGeneratorBuilder
 from dreamsboard.engine.generate.code_generate import (
@@ -96,14 +97,7 @@ def test_engine() -> None:
 
 
 def test_code():
-    llm = ChatOpenAI(
-        openai_api_base="https://open.bigmodel.cn/api/paas/v4/",
-        model="glm-4-airx",
-        openai_api_key="12",
-        verbose=True,
-        temperature=0.95,
-        top_p=0.70,
-    )
+    llm = create_chat_openai(profile="glm4_airx_guidance")
     critic_system_prompt_template = PromptTemplate(
         input_variables=[
             "problem",
@@ -159,7 +153,6 @@ def test_code1():
         SystemMessagePromptTemplate,
     )
     from langchain.schema import AIMessage, HumanMessage, SystemMessage
-    from langchain_community.chat_models import ChatOpenAI
 
     messages = []
     messages.append(

--- a/src/dreamsboard/tests/integration_tests/test_engine_storyboard.py
+++ b/src/dreamsboard/tests/integration_tests/test_engine_storyboard.py
@@ -1,7 +1,8 @@
 import logging
 
 import langchain
-from langchain_community.chat_models import ChatOpenAI
+
+from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
 from dreamsboard.dreams.builder_cosplay_code.base import StructuredDreamsStoryboard
 from dreamsboard.dreams.dreams_personality_chain.base import (
@@ -20,7 +21,7 @@ logger.addHandler(handler)
 
 
 def test_structured_dreams_storyboard() -> None:
-    llm = ChatOpenAI(verbose=True)
+    llm = create_chat_openai(profile="verbose")
 
     dreams_generation_chain = StoryBoardDreamsGenerationChain.from_dreams_personality_chain(
         llm_runable=llm,

--- a/src/dreamsboard/tests/integration_tests/test_event_manager/test_event_manager.py
+++ b/src/dreamsboard/tests/integration_tests/test_event_manager/test_event_manager.py
@@ -4,7 +4,6 @@ import threading
 
 from langchain.prompts import PromptTemplate
 from langchain.schema import AIMessage
-from langchain_community.chat_models import ChatOpenAI
 
 from dreamsboard.common.callback import event_manager
 from dreamsboard.document_loaders.structured_storyboard_loader import LinkedListNode

--- a/src/dreamsboard/tests/integration_tests/test_gpt4o/test_engine_storyboard_store_drop_his.py
+++ b/src/dreamsboard/tests/integration_tests/test_gpt4o/test_engine_storyboard_store_drop_his.py
@@ -1,7 +1,6 @@
 import logging
 
 import langchain
-from langchain_community.chat_models import ChatOpenAI
 
 from dreamsboard.dreams.builder_cosplay_code.base import StructuredDreamsStoryboard
 from dreamsboard.dreams.dreams_personality_chain.base import (

--- a/src/dreamsboard/tests/integration_tests/test_gpt4o/test_engine_storyboard_store_test_gpt4o.py
+++ b/src/dreamsboard/tests/integration_tests/test_gpt4o/test_engine_storyboard_store_test_gpt4o.py
@@ -1,10 +1,11 @@
 import logging
 
 import langchain
-from langchain_community.chat_models import ChatOpenAI
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import PromptTemplate
 from langchain_core.runnables import RunnableLambda
+
+from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
 from dreamsboard.document_loaders import StructuredStoryboardCSVBuilder
 from dreamsboard.dreams.builder_cosplay_code.base import StructuredDreamsStoryboard
@@ -38,16 +39,8 @@ logger.addHandler(handler)
 
 
 def test_structured_dreams_storyboard_store_test_gpt4o(setup_log) -> None:
-    llm = ChatOpenAI(
-        model="gpt-4o",
-        verbose=True,
-    )
-    guidance_llm = ChatOpenAI(
-        model="gpt-4o",
-        verbose=True,
-        temperature=0.95,
-        top_p=0.70,
-    )
+    llm = create_chat_openai(profile="gpt4o")
+    guidance_llm = create_chat_openai(profile="gpt4o_guidance")
     try:
         storage_context = StorageContext.from_defaults(
             persist_dir="./ieAjabk1_keyframe"

--- a/src/dreamsboard/tests/integration_tests/test_kor/test_kor1.py
+++ b/src/dreamsboard/tests/integration_tests/test_kor/test_kor1.py
@@ -2,18 +2,12 @@ import os
 
 from kor.extraction import create_extraction_chain
 from kor.nodes import Number, Object, Text
-from langchain_community.chat_models import ChatOpenAI
+
+from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
 
 def test_kor():
-    llm = ChatOpenAI(
-        openai_api_base="http://127.0.0.1:30000/v1",
-        model="glm-3-turbo",
-        openai_api_key="glm-4",
-        verbose=True,
-        temperature=0.95,
-        top_p=0.70,
-    )
+    llm = create_chat_openai(profile="glm3_local_guidance")
     # @title 长的prompt
 
     schema = Object(

--- a/src/dreamsboard/tests/integration_tests/test_kor/test_kor2.py
+++ b/src/dreamsboard/tests/integration_tests/test_kor/test_kor2.py
@@ -2,18 +2,12 @@ import os
 
 from kor.extraction import create_extraction_chain
 from kor.nodes import Number, Object, Text
-from langchain_community.chat_models import ChatOpenAI
+
+from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
 
 def test_kor2():
-    llm = ChatOpenAI(
-        openai_api_base="http://127.0.0.1:30000/v1",
-        model="glm-4",
-        openai_api_key="glm-4",
-        verbose=True,
-        temperature=0.1,
-        top_p=0.9,
-    )
+    llm = create_chat_openai(profile="glm4_local_low_temp")
     # @title 长的prompt
     schema = Object(
         id="script",

--- a/src/dreamsboard/tests/integration_tests/test_kor/test_kor3.py
+++ b/src/dreamsboard/tests/integration_tests/test_kor/test_kor3.py
@@ -2,18 +2,12 @@ import os
 
 from kor.extraction import create_extraction_chain
 from kor.nodes import Number, Object, Text
-from langchain_community.chat_models import ChatOpenAI
+
+from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
 
 def test_kor3():
-    llm = ChatOpenAI(
-        openai_api_base="https://open.bigmodel.cn/api/paas/v4",
-        model="glm-4",
-        openai_api_key="testkey",
-        verbose=True,
-        temperature=0.1,
-        top_p=0.9,
-    )
+    llm = create_chat_openai(profile="glm4_remote_low_temp")
     # @title 长的prompt
     schema = Object(
         id="script",

--- a/src/dreamsboard/tests/integration_tests/test_runnable/test_create_structured_output_runnable.py
+++ b/src/dreamsboard/tests/integration_tests/test_runnable/test_create_structured_output_runnable.py
@@ -3,9 +3,10 @@ from typing import Optional
 
 import langchain
 from langchain.chains.openai_functions import create_structured_output_runnable
-from langchain_community.chat_models import ChatOpenAI
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.pydantic_v1 import BaseModel, Field
+
+from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
 langchain.verbose = True
 logger = logging.getLogger(__name__)
@@ -26,12 +27,7 @@ class Personality(BaseModel):
 
 def test_create_structured_output_runnable() -> None:
     """Test create_structured_output_runnable. 测试创建结构化输出可运行对象。"""
-    llm = ChatOpenAI(
-        openai_api_base="http://127.0.0.1:30000/v1",
-        model="glm-4",
-        openai_api_key="glm-4",
-        verbose=True,
-    )
+    llm = create_chat_openai(profile="glm4_local_verbose")
     prompt = ChatPromptTemplate.from_messages(
         [
             (

--- a/src/dreamsboard/tests/integration_tests/test_runnable/test_create_structured_output_runnable2.py
+++ b/src/dreamsboard/tests/integration_tests/test_runnable/test_create_structured_output_runnable2.py
@@ -3,9 +3,10 @@ from typing import List, Optional
 
 import langchain
 from langchain.chains.openai_functions import create_structured_output_runnable
-from langchain_community.chat_models import ChatOpenAI
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.pydantic_v1 import BaseModel, Field
+
+from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
 from dreamsboard.document_loaders.protocol.ner_protocol import (
     DreamsStepInfo,
@@ -25,14 +26,7 @@ logger.addHandler(handler)
 
 def test_create_structured_output_runnable2() -> None:
     """Test create_structured_output_runnable. 测试创建结构化输出可运行对象。"""
-    llm = ChatOpenAI(
-        openai_api_base="http://127.0.0.1:30000/v1",
-        model="glm-4",
-        openai_api_key="glm-4",
-        verbose=True,
-        temperature=0.1,
-        top_p=0.9,
-    )
+    llm = create_chat_openai(profile="glm4_local_low_temp")
     prompt = ChatPromptTemplate.from_messages(
         [
             (

--- a/src/dreamsboard/tests/integration_tests/test_runnable_itemgetter/test_runnable_parallel_chain.py
+++ b/src/dreamsboard/tests/integration_tests/test_runnable_itemgetter/test_runnable_parallel_chain.py
@@ -8,7 +8,9 @@ from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain_core.runnables import RunnablePassthrough
-from langchain_openai import ChatOpenAI, OpenAIEmbeddings
+from langchain_openai import OpenAIEmbeddings
+
+from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
 langchain.verbose = True
 logger = logging.getLogger(__name__)
@@ -26,15 +28,8 @@ def test_runnable_parallel_chain() -> None:
 
     from langchain_core.prompts import ChatPromptTemplate
     from langchain_core.runnables import RunnableParallel
-    from langchain_openai import ChatOpenAI
 
-    llm = ChatOpenAI(
-        openai_api_base="http://127.0.0.1:30000/v1",
-        model="glm-4",
-        openai_api_key="glm-4",
-        verbose=True,
-        # temperature=0.95,
-    )
+    llm = create_chat_openai(profile="glm4_local_verbose")
     joke_chain = (
         ChatPromptTemplate.from_template("tell me a joke about {topic}")
         | llm

--- a/src/dreamsboard/tests/integration_tests/test_structured_storyboard_loader/test_structured_storyboard_loader.py
+++ b/src/dreamsboard/tests/integration_tests/test_structured_storyboard_loader/test_structured_storyboard_loader.py
@@ -2,8 +2,6 @@ import json
 import logging
 import os
 
-from langchain_community.chat_models import ChatOpenAI
-
 from dreamsboard.document_loaders.structured_storyboard_loader import (
     StructuredStoryboard,
 )
@@ -13,6 +11,8 @@ from dreamsboard.engine.storage.task_step_store.simple_task_step_store import (
     SimpleTaskStepStore,
 )
 from dreamsboard.engine.utils import concat_dirs
+
+from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -30,23 +30,9 @@ logger.addHandler(handler)
 """
 
 
-def test_structured_storyboard_loader():
-    llm = ChatOpenAI(
-        openai_api_base="https://open.bigmodel.cn/api/paas/v4",
-        model="glm-4-plus",
-        openai_api_key="testkey",
-        verbose=True,
-        temperature=0.1,
-        top_p=0.9,
-    )
-    kor_dreams_task_step_llm = ChatOpenAI(
-        openai_api_base="https://open.bigmodel.cn/api/paas/v4",
-        model="glm-4-plus",
-        openai_api_key="testkey",
-        verbose=True,
-        temperature=0.95,
-        top_p=0.70,
-    )
+def test_structured_storyboard_loader(start_task_context: str):
+    llm = create_chat_openai(profile="glm4_plus_low_temp")
+    kor_dreams_task_step_llm = create_chat_openai(profile="glm4_plus_guidance")
     from tests.integration_tests.test_aemo_representation_chain.prompts import (
         AEMO_REPRESENTATION_PROMPT_TEMPLATE as AEMO_REPRESENTATION_PROMPT_TEMPLATE_TEST,
     )
@@ -56,7 +42,7 @@ def test_structured_storyboard_loader():
     ] = AEMO_REPRESENTATION_PROMPT_TEMPLATE_TEST
     aemo_representation_chain = AEMORepresentationChain.from_aemo_representation_chain(
         llm=llm,
-        start_task_context="有哪些方法可以提升大模型的规划能力，各自优劣是什么？",
+        start_task_context=start_task_context,
         kor_dreams_task_step_llm=kor_dreams_task_step_llm,
     )
 

--- a/src/dreamsboard/tests/integration_tests/test_task_step_to_question_chain/test_task_step_to_question_chain.py
+++ b/src/dreamsboard/tests/integration_tests/test_task_step_to_question_chain/test_task_step_to_question_chain.py
@@ -1,9 +1,11 @@
 import json
 import logging
-import os
+from typing import Callable
 
-from langchain_community.chat_models import ChatOpenAI
-from sentence_transformers import CrossEncoder
+import pytest
+
+sentence_transformers = pytest.importorskip("sentence_transformers")
+CrossEncoder = sentence_transformers.CrossEncoder
 
 from dreamsboard.document_loaders.csv_structured_storyboard_loader import (
     StructuredStoryboardCSVBuilder,
@@ -36,45 +38,72 @@ logger.addHandler(handler)
 召回问题前3条,存入task_step_question_context
 调用llm，生成task_step_question_answer
 """
+@pytest.fixture
+def llm(chat_openai_factory: Callable[..., object]) -> object:
+    """Provide a deterministic ChatOpenAI-compatible client."""
+
+    return chat_openai_factory(temperature=0.1, top_p=0.9, verbose=True)
 
 
-def test_invoke_task_step_to_question():
-    llm = ChatOpenAI(
-        openai_api_base="https://open.bigmodel.cn/api/paas/v4",
-        model="glm-4-plus",
-        openai_api_key="testkey",
-        verbose=True,
-        temperature=0.1,
-        top_p=0.9,
-    )
-    task_step_store = SimpleTaskStepStore.from_persist_dir(persist_dir="./storage")
+@pytest.fixture
+def task_step_store() -> SimpleTaskStepStore:
+    """Load the persisted task step store for integration tests."""
 
-    os.environ["ZHIPUAI_API_KEY"] = "testkey"
+    return SimpleTaskStepStore.from_persist_dir(persist_dir="./storage")
 
-    cross_encoder_path = "/media/checkpoint/jina-reranker-v2-base-multilingual"
-    start_task_context = "有哪些方法可以提升大模型的规划能力，各自优劣是什么？"
-    collection_id = get_query_hash(start_task_context)
-    collection = FaissCollectionService(
-        kb_name=collection_id,
-        embed_model="/media/checkpoint/m3e-base",
-        vector_name="samples",
-        device="cpu",
-    )
-    cross_encoder = CrossEncoder(
+
+@pytest.fixture(scope="session")
+def cross_encoder(cross_encoder_path: str) -> CrossEncoder:
+    """Instantiate the cross-encoder model declared for integration tests."""
+
+    return CrossEncoder(
         cross_encoder_path,
         automodel_args={"torch_dtype": "auto"},
         trust_remote_code=True,
     )
 
-    task_step_to_question_chain = (
-        TaskStepToQuestionChain.from_task_step_to_question_chain(
-            base_path="./",
-            llm_runable=llm,
-            start_task_context=start_task_context,
-            task_step_store=task_step_store,
-            collection=collection,
-            cross_encoder=cross_encoder,
-        )
+
+@pytest.fixture
+def collection(start_task_context: str, embed_model_path: str) -> FaissCollectionService:
+    """Return a FAISS collection service bound to the shared task context."""
+
+    collection_id = get_query_hash(start_task_context)
+    collection = FaissCollectionService(
+        kb_name=collection_id,
+        embed_model=embed_model_path,
+        vector_name="samples",
+        device="cpu",
+    )
+    yield collection
+    collection.do_clear_vs()
+
+
+def _build_chain(
+    llm: object,
+    start_task_context: str,
+    task_step_store: SimpleTaskStepStore,
+    collection: FaissCollectionService,
+    cross_encoder: CrossEncoder,
+) -> TaskStepToQuestionChain:
+    return TaskStepToQuestionChain.from_task_step_to_question_chain(
+        base_path="./",
+        llm_runable=llm,
+        start_task_context=start_task_context,
+        task_step_store=task_step_store,
+        collection=collection,
+        cross_encoder=cross_encoder,
+    )
+
+
+def test_invoke_task_step_to_question(
+    llm: object,
+    start_task_context: str,
+    task_step_store: SimpleTaskStepStore,
+    collection: FaissCollectionService,
+    cross_encoder: CrossEncoder,
+):
+    task_step_to_question_chain = _build_chain(
+        llm, start_task_context, task_step_store, collection, cross_encoder
     )
 
     task_step_id = list(task_step_store.task_step_all.keys())[0]
@@ -82,97 +111,39 @@ def test_invoke_task_step_to_question():
     assert task_step_store.task_step_all is not None
 
     task_step_store_path = concat_dirs(
-        dirname=f"./storage", basename=DEFAULT_PERSIST_FNAME
+        dirname="./storage", basename=DEFAULT_PERSIST_FNAME
     )
     task_step_store.persist(persist_path=task_step_store_path)
 
 
-def test_invoke_task_step_question_context():
-    llm = ChatOpenAI(
-        openai_api_base="https://open.bigmodel.cn/api/paas/v4",
-        model="glm-4-plus",
-        openai_api_key="testkey",
-        verbose=True,
-        temperature=0.1,
-        top_p=0.9,
-    )
-    os.environ["ZHIPUAI_API_KEY"] = "testkey"
-    task_step_store = SimpleTaskStepStore.from_persist_dir(persist_dir="./storage")
-
-    cross_encoder_path = "/media/checkpoint/jina-reranker-v2-base-multilingual"
-
-    start_task_context = "有哪些方法可以提升大模型的规划能力，各自优劣是什么？"
-    collection_id = get_query_hash(start_task_context)
-    collection = FaissCollectionService(
-        kb_name=collection_id,
-        embed_model="/media/checkpoint/m3e-base",
-        vector_name="samples",
-        device="cpu",
-    )
-
-    cross_encoder = CrossEncoder(
-        cross_encoder_path,
-        automodel_args={"torch_dtype": "auto"},
-        trust_remote_code=True,
-    )
-
-    task_step_to_question_chain = (
-        TaskStepToQuestionChain.from_task_step_to_question_chain(
-            base_path="./",
-            llm_runable=llm,
-            start_task_context=start_task_context,
-            task_step_store=task_step_store,
-            collection=collection,
-            cross_encoder=cross_encoder,
-        )
+def test_invoke_task_step_question_context(
+    llm: object,
+    start_task_context: str,
+    task_step_store: SimpleTaskStepStore,
+    collection: FaissCollectionService,
+    cross_encoder: CrossEncoder,
+):
+    task_step_to_question_chain = _build_chain(
+        llm, start_task_context, task_step_store, collection, cross_encoder
     )
     task_step_id = list(task_step_store.task_step_all.keys())[0]
     task_step_to_question_chain.invoke_task_step_question_context(task_step_id)
     assert task_step_store.task_step_all is not None
     task_step_store_path = concat_dirs(
-        dirname=f"./storage", basename=DEFAULT_PERSIST_FNAME
+        dirname="./storage", basename=DEFAULT_PERSIST_FNAME
     )
     task_step_store.persist(persist_path=task_step_store_path)
 
 
-def test_export_csv_file_path():
-    llm = ChatOpenAI(
-        openai_api_base="https://open.bigmodel.cn/api/paas/v4",
-        model="glm-4-plus",
-        openai_api_key="testkey",
-        verbose=True,
-        temperature=0.1,
-        top_p=0.9,
-    )
-    os.environ["ZHIPUAI_API_KEY"] = "testkey"
-    task_step_store = SimpleTaskStepStore.from_persist_dir(persist_dir="./storage")
-
-    cross_encoder_path = "/media/checkpoint/jina-reranker-v2-base-multilingual"
-
-    start_task_context = "有哪些方法可以提升大模型的规划能力，各自优劣是什么？"
-    collection_id = get_query_hash(start_task_context)
-    collection = FaissCollectionService(
-        kb_name=collection_id,
-        embed_model="/media/checkpoint/m3e-base",
-        vector_name="samples",
-        device="cpu",
-    )
-
-    cross_encoder = CrossEncoder(
-        cross_encoder_path,
-        automodel_args={"torch_dtype": "auto"},
-        trust_remote_code=True,
-    )
-
-    task_step_to_question_chain = (
-        TaskStepToQuestionChain.from_task_step_to_question_chain(
-            base_path="./",
-            llm_runable=llm,
-            start_task_context=start_task_context,
-            task_step_store=task_step_store,
-            collection=collection,
-            cross_encoder=cross_encoder,
-        )
+def test_export_csv_file_path(
+    llm: object,
+    start_task_context: str,
+    task_step_store: SimpleTaskStepStore,
+    collection: FaissCollectionService,
+    cross_encoder: CrossEncoder,
+):
+    task_step_to_question_chain = _build_chain(
+        llm, start_task_context, task_step_store, collection, cross_encoder
     )
 
     task_step_id = list(task_step_store.task_step_all.keys())[0]
@@ -181,7 +152,7 @@ def test_export_csv_file_path():
     assert csv_file_path is not None
 
     builder = StructuredStoryboardCSVBuilder(csv_file_path=csv_file_path)
-    builder.load()  # 替换为你的CSV文件路径
+    builder.load()
     selected_columns = ["story_board_role", "story_board_text", "story_board"]
     formatted_text = builder.build_text(task_step_id, selected_columns)
     logger.info("formatted_text:" + formatted_text)

--- a/src/dreamsboard/tests/integration_tests/test_threading_faiss_kb/test_threading_faiss_kb.py
+++ b/src/dreamsboard/tests/integration_tests/test_threading_faiss_kb/test_threading_faiss_kb.py
@@ -8,14 +8,17 @@ from dreamsboard.vector.faiss_kb_service import FaissCollectionService
 
 
 @pytest.fixture
-def faiss_service():
-    """Fixture to create a FaissKBService instance."""
-    return FaissCollectionService(
+def faiss_service(embed_model_path: str) -> FaissCollectionService:
+    """Fixture to create a FAISS collection bound to the configured embeddings."""
+
+    service = FaissCollectionService(
         kb_name="faiss",
-        embed_model="/media/checkpoint/m3e-base",
+        embed_model=embed_model_path,
         vector_name="samples",
         device="cpu",
     )
+    yield service
+    service.do_clear_vs()
 
 
 @pytest.mark.parametrize(

--- a/src/dreamsboard/tests/integration_tests/utils/environment.py
+++ b/src/dreamsboard/tests/integration_tests/utils/environment.py
@@ -1,0 +1,268 @@
+"""Integration Test Environment:
+Requires external API access.
+Set the following environment variables before running:
+  - OPENAI_API_KEY
+  - CROSS_ENCODER_PATH
+  - EMBED_MODEL_PATH
+Optionally configure ChatOpenAI profiles via ``CHAT_OPENAI_PROFILES_PATH``
+or ``CHAT_OPENAI_PROFILES_JSON``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+import pytest
+
+CHAT_OPENAI_IMPORT_SKIP = "Skipping test: ChatOpenAI dependency is not installed."
+
+REQUIRED_ENV_VARS: tuple[str, ...] = ("OPENAI_API_KEY",)
+OPTIONAL_ENV_VARS: tuple[str, ...] = (
+    "CROSS_ENCODER_PATH",
+    "EMBED_MODEL_PATH",
+)
+ALL_ENV_VARS: tuple[str, ...] = REQUIRED_ENV_VARS + OPTIONAL_ENV_VARS
+SKIP_MESSAGE = "Skipping test: Missing external API credentials."
+OPTIONAL_SKIP_TEMPLATE = (
+    "Skipping test: {name} is required for this integration test."
+)
+START_TASK_CONTEXT: Path = (
+    Path(__file__).resolve().parents[1] / "fixtures" / "task_context.json"
+)
+DEFAULT_CHAT_MODEL = os.getenv("CHAT_OPENAI_MODEL", "gpt-4o-mini")
+CHAT_OPENAI_DEFAULTS: Dict[str, Any] = {
+    "model": DEFAULT_CHAT_MODEL,
+    "temperature": float(os.getenv("CHAT_OPENAI_TEMPERATURE", "0")),
+    "max_retries": int(os.getenv("CHAT_OPENAI_MAX_RETRIES", "2")),
+    "request_timeout": int(
+        os.getenv("CHAT_OPENAI_TIMEOUT", "120")
+    ),
+}
+
+DEFAULT_CHAT_OPENAI_PROFILES_PATH: Path = (
+    Path(__file__).resolve().parents[1] / "config" / "chat_openai_profiles.json"
+)
+CHAT_OPENAI_PROFILES_ENV = "CHAT_OPENAI_PROFILES_JSON"
+CHAT_OPENAI_PROFILES_PATH_ENV = "CHAT_OPENAI_PROFILES_PATH"
+ENV_VALUE_PREFIX = "env:"
+CHAT_OPENAI_PROFILE_SKIP_TEMPLATE = (
+    "Skipping test: ChatOpenAI profile '{profile}' requires '{variable}'."
+)
+
+
+def missing_required_env_vars(env: Iterable[str] | None = None) -> List[str]:
+    """Return the required environment variables that are not set."""
+
+    env = env or REQUIRED_ENV_VARS
+    return [var for var in env if not os.getenv(var)]
+
+
+def ensure_external_services_available() -> None:
+    """Skip the current test when required credentials are missing."""
+
+    missing = missing_required_env_vars()
+    if missing:
+        pytest.skip(SKIP_MESSAGE)
+
+
+def get_env_path(name: str) -> Optional[Path]:
+    """Return a :class:`~pathlib.Path` for ``name`` when it is configured."""
+
+    value = os.getenv(name)
+    if not value:
+        return None
+    return Path(value).expanduser().resolve()
+
+
+def require_env_path(name: str) -> Path:
+    """Return the resolved path for ``name`` or skip the current test."""
+
+    path = get_env_path(name)
+    if path is None:
+        pytest.skip(OPTIONAL_SKIP_TEMPLATE.format(name=name))
+    if not path.exists():
+        pytest.skip(
+            OPTIONAL_SKIP_TEMPLATE.format(
+                name=f"{name} (missing resource at {path})"
+            )
+        )
+    return path
+
+
+def load_start_task_context(path: Optional[Path] = None) -> Dict[str, Any]:
+    """Load the shared start task context JSON payload."""
+
+    context_path = Path(path or START_TASK_CONTEXT)
+    if not context_path.exists():
+        raise FileNotFoundError(
+            f"Unable to locate shared task context file: {context_path}"
+        )
+    with context_path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _import_chat_openai() -> Type[Any]:
+    """Return the available ``ChatOpenAI`` implementation or skip the test."""
+
+    try:
+        from langchain_openai import ChatOpenAI as Impl  # type: ignore
+
+        return Impl
+    except ImportError:
+        try:
+            from langchain_community.chat_models import ChatOpenAI as Impl  # type: ignore
+
+            return Impl
+        except ImportError:
+            pytest.skip(CHAT_OPENAI_IMPORT_SKIP)
+
+
+def resolve_chat_openai_class() -> type[Any]:
+    """Return the available ``ChatOpenAI`` implementation or skip the test."""
+
+    return _import_chat_openai()
+
+
+def _load_profiles_from_path(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _raw_chat_openai_profiles() -> Dict[str, Any]:
+    raw: Dict[str, Any] = {}
+
+    env_json = os.getenv(CHAT_OPENAI_PROFILES_ENV)
+    if env_json:
+        try:
+            raw.update(json.loads(env_json))
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive branch
+            raise ValueError(
+                "Invalid JSON provided via"
+                f" {CHAT_OPENAI_PROFILES_ENV}: {exc}"  # noqa: EM102
+            ) from exc
+
+    env_path = os.getenv(CHAT_OPENAI_PROFILES_PATH_ENV)
+    if env_path:
+        raw.update(_load_profiles_from_path(Path(env_path).expanduser().resolve()))
+
+    if DEFAULT_CHAT_OPENAI_PROFILES_PATH.exists():
+        raw.update(_load_profiles_from_path(DEFAULT_CHAT_OPENAI_PROFILES_PATH))
+
+    profiles = raw.get("profiles", raw)
+    if not isinstance(profiles, dict):  # pragma: no cover - defensive branch
+        raise ValueError("ChatOpenAI profiles must be a mapping of names to configs.")
+    return profiles
+
+
+def _resolve_profile_value(
+    profile: str, key: str, value: Any, skip_message: str
+) -> Any:
+    if isinstance(value, str) and value.startswith(ENV_VALUE_PREFIX):
+        spec = value[len(ENV_VALUE_PREFIX) :]
+        variable, _, fallback = spec.partition("||")
+        env_value = os.getenv(variable)
+        if env_value is None:
+            if fallback:
+                if fallback.startswith(ENV_VALUE_PREFIX):
+                    return _resolve_profile_value(profile, key, fallback, skip_message)
+                return fallback
+            pytest.skip(
+                CHAT_OPENAI_PROFILE_SKIP_TEMPLATE.format(
+                    profile=profile, variable=variable
+                )
+            )
+        return env_value
+    if value == "<skip>":
+        pytest.skip(skip_message)
+    return value
+
+
+def _build_chat_openai_profiles() -> Dict[str, Dict[str, Any]]:
+    raw_profiles = _raw_chat_openai_profiles()
+    built: Dict[str, Dict[str, Any]] = {}
+
+    def _build(profile: str, stack: Optional[List[str]] = None) -> Dict[str, Any]:
+        if profile in built:
+            return built[profile]
+
+        stack = stack or []
+        if profile in stack:  # pragma: no cover - defensive branch
+            raise ValueError(f"Circular ChatOpenAI profile inheritance: {stack + [profile]}")
+
+        entry = raw_profiles.get(profile, {})
+        inherit = entry.get("inherit") if isinstance(entry, dict) else None
+        base = CHAT_OPENAI_DEFAULTS.copy()
+        if inherit:
+            base.update(_build(inherit, stack + [profile]))
+
+        if isinstance(entry, dict):
+            params = entry.get("parameters", {})
+            if not params:
+                params = {key: value for key, value in entry.items() if key != "inherit"}
+        else:  # pragma: no cover - defensive branch
+            params = {}
+
+        resolved = {
+            key: _resolve_profile_value(profile, key, value, SKIP_MESSAGE)
+            for key, value in params.items()
+        }
+        merged = {key: value for key, value in {**base, **resolved}.items() if value is not None}
+        built[profile] = merged
+        return merged
+
+    profiles_to_build = set(raw_profiles) | {"default"}
+    for profile_name in profiles_to_build:
+        _build(profile_name)
+
+    return built
+
+
+CHAT_OPENAI_PROFILES: Dict[str, Dict[str, Any]] = _build_chat_openai_profiles()
+
+
+def get_chat_openai_profile(profile: str = "default") -> Dict[str, Any]:
+    """Return the resolved ChatOpenAI parameter set for ``profile``."""
+
+    if profile not in CHAT_OPENAI_PROFILES:
+        available = ", ".join(sorted(CHAT_OPENAI_PROFILES))
+        raise KeyError(
+            f"Unknown ChatOpenAI profile '{profile}'. Available profiles: {available}."
+        )
+    return CHAT_OPENAI_PROFILES[profile].copy()
+
+
+def create_chat_openai(profile: str = "default", **overrides: Any) -> Any:
+    """Instantiate a ChatOpenAI-compatible object using an environment profile."""
+
+    ensure_external_services_available()
+    params = get_chat_openai_profile(profile)
+    params.update(overrides)
+    params = {key: value for key, value in params.items() if value is not None}
+
+    chat_cls = resolve_chat_openai_class()
+    return chat_cls(**params)
+
+
+__all__ = [
+    "ALL_ENV_VARS",
+    "CHAT_OPENAI_DEFAULTS",
+    "CHAT_OPENAI_PROFILES",
+    "CHAT_OPENAI_IMPORT_SKIP",
+    "OPTIONAL_SKIP_TEMPLATE",
+    "REQUIRED_ENV_VARS",
+    "SKIP_MESSAGE",
+    "START_TASK_CONTEXT",
+    "create_chat_openai",
+    "ensure_external_services_available",
+    "get_chat_openai_profile",
+    "get_env_path",
+    "resolve_chat_openai_class",
+    "require_env_path",
+    "load_start_task_context",
+    "missing_required_env_vars",
+]


### PR DESCRIPTION
## Summary
- remove MockChatOpenAI hooks and pytest flags from the integration fixtures
- load ChatOpenAI clients via environment-provided defaults and profile paths for consistent setup
- update the integration README, prompt annotations, and `.env.example` to reflect the required credentials and overrides

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68ed28cb1720832794d98c8f5186c3e6