### PR TITLE
Remove deprecated chat_openai helper

### DIFF
--- a/src/dreamsboard/tests/README.md
+++ b/src/dreamsboard/tests/README.md
@@ -25,13 +25,12 @@ This guide documents the environment requirements for `src/dreamsboard/tests/int
 
 - **版本与导入**：默认使用 `langchain_openai.ChatOpenAI` 或 `langchain_community.chat_models.ChatOpenAI`。
 - **默认配置**：`CHAT_OPENAI_DEFAULTS` 中定义，模型默认为 `gpt-4o-mini`，`temperature=0`，`max_retries=2`，`request_timeout=120s`。
-- **环境 Profile**：使用 `create_chat_openai(profile="<name>")` 调用 `config/chat_openai_profiles.json` 中定义的参数集合，例如：
+- **环境 Profile**：在测试中通过 `chat_openai_factory(profile="<name>")` 调用 `config/chat_openai_profiles.json` 中定义的参数集合，例如：
 
   ```python
-  from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
-
-  llm = create_chat_openai(profile="glm4_plus_low_temp")
-  guidance_llm = create_chat_openai(profile="glm4_plus_guidance")
+  def test_llm(chat_openai_factory):
+      llm = chat_openai_factory(profile="glm4_plus_low_temp")
+      guidance_llm = chat_openai_factory(profile="glm4_plus_guidance")
   ```
 
   Profile 支持环境变量占位符（如 `env:OPENAI_API_BASE` 或带回退的 `env:DEEPSEEK_API_BASE||env:OPENAI_API_BASE`），缺失时会 `pytest.skip` 提示所需变量。

--- a/src/dreamsboard/tests/integration_tests/conftest.py
+++ b/src/dreamsboard/tests/integration_tests/conftest.py
@@ -100,13 +100,6 @@ def chat_openai_factory(
     return _factory
 
 
-@pytest.fixture
-def chat_openai(chat_openai_factory: Callable[..., Any]) -> Any:
-    """Provide a default ChatOpenAI-compatible instance."""
-
-    return chat_openai_factory()
-
-
 @pytest.fixture(scope="session")
 def cross_encoder_path() -> str:
     """Return the configured cross-encoder model path or skip if missing."""

--- a/src/dreamsboard/tests/integration_tests/kor/test_kor.py
+++ b/src/dreamsboard/tests/integration_tests/kor/test_kor.py
@@ -1,4 +1,4 @@
-from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
+from typing import Callable
 
 from dreamsboard.document_loaders import KorLoader
 from dreamsboard.document_loaders.protocol.ner_protocol import DreamsStepInfo
@@ -7,7 +7,7 @@ from dreamsboard.engine.storage.dreams_analysis_store.simple_dreams_analysis_sto
 )
 
 
-def test_kor_glm_3():
+def test_kor_glm_3(chat_openai_factory: Callable[..., object]) -> None:
     dreams_analysis_store = SimpleDreamsAnalysisStore.from_persist_dir(
         persist_dir="./storage"
     )
@@ -16,7 +16,7 @@ def test_kor_glm_3():
     for val in dreams_analysis_store.analysis_all.values():
         dreams_guidance_context = val.dreams_guidance_context
         dreams_personality_context = val.dreams_personality_context
-    guidance_llm = create_chat_openai(profile="glm4_gateway_guidance")
+    guidance_llm = chat_openai_factory(profile="glm4_gateway_guidance")
     kor_dreams_guidance_chain = KorLoader.form_kor_dreams_guidance_builder(
         llm_runable=guidance_llm
     )
@@ -38,7 +38,7 @@ def test_kor_glm_3():
     print(dreams_step_list)
 
 
-def test_kor_glm_4():
+def test_kor_glm_4(chat_openai_factory: Callable[..., object]) -> None:
     dreams_analysis_store = SimpleDreamsAnalysisStore.from_persist_dir(
         persist_dir="./storage"
     )
@@ -47,7 +47,7 @@ def test_kor_glm_4():
     for val in dreams_analysis_store.analysis_all.values():
         dreams_guidance_context = val.dreams_guidance_context
         dreams_personality_context = val.dreams_personality_context
-    guidance_llm = create_chat_openai(profile="glm4_remote_guidance_slash")
+    guidance_llm = chat_openai_factory(profile="glm4_remote_guidance_slash")
     kor_dreams_guidance_chain = KorLoader.form_kor_dreams_guidance_builder(
         llm_runable=guidance_llm
     )

--- a/src/dreamsboard/tests/integration_tests/story_board_dreams_generation_chain.py
+++ b/src/dreamsboard/tests/integration_tests/story_board_dreams_generation_chain.py
@@ -1,8 +1,7 @@
 import logging
+from typing import Callable
 
 import langchain
-
-from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
 from dreamsboard.dreams.dreams_personality_chain.base import (
     StoryBoardDreamsGenerationChain,
@@ -19,7 +18,9 @@ handler.setLevel(logging.INFO)
 logger.addHandler(handler)
 
 
-def test_story_board_dreams_generation_chain():
+def test_story_board_dreams_generation_chain(
+    chat_openai_factory: Callable[..., object]
+) -> None:
     # os.environ["LANGCHAIN_WANDB_TRACING"] = "true"
 
     # wandb documentation to configure wandb using env variables
@@ -27,7 +28,7 @@ def test_story_board_dreams_generation_chain():
     # here we are configuring the wandb project name
     # os.environ["WANDB_PROJECT"] = "StoryBoardDreamsGenerationChain"
     # os.environ["WANDB_API_KEY"] = "key"
-    llm = create_chat_openai(profile="verbose")
+    llm = chat_openai_factory(profile="verbose")
 
     dreams_generation_chain = StoryBoardDreamsGenerationChain.from_dreams_personality_chain(
         llm_runable=llm,

--- a/src/dreamsboard/tests/integration_tests/test_aemo_representation_chain/test_aemo_representation_chain.py
+++ b/src/dreamsboard/tests/integration_tests/test_aemo_representation_chain/test_aemo_representation_chain.py
@@ -1,8 +1,7 @@
 import json
 import logging
 import os
-
-from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
+from typing import Callable
 
 from dreamsboard.dreams.aemo_representation_chain.base import AEMORepresentationChain
 from dreamsboard.engine.entity.task_step.task_step import TaskStepNode
@@ -27,8 +26,10 @@ logger.addHandler(handler)
 """
 
 
-def test_aemo_representation_chain_context(start_task_context: str):
-    llm = create_chat_openai(profile="glm4_plus_low_temp")
+def test_aemo_representation_chain_context(
+    start_task_context: str, chat_openai_factory: Callable[..., object]
+):
+    llm = chat_openai_factory(profile="glm4_plus_low_temp")
     aemo_representation_chain = AEMORepresentationChain.from_aemo_representation_chain(
         llm_runable=llm,
         start_task_context=start_task_context,
@@ -40,8 +41,10 @@ def test_aemo_representation_chain_context(start_task_context: str):
     assert result.get("aemo_representation_context") is not None
 
 
-def test_aemo_representation_chain_custom_prompt(start_task_context: str):
-    llm = create_chat_openai(profile="glm4_plus_low_temp")
+def test_aemo_representation_chain_custom_prompt(
+    start_task_context: str, chat_openai_factory: Callable[..., object]
+):
+    llm = chat_openai_factory(profile="glm4_plus_low_temp")
     from tests.integration_tests.test_aemo_representation_chain.prompts import (
         AEMO_REPRESENTATION_PROMPT_TEMPLATE as AEMO_REPRESENTATION_PROMPT_TEMPLATE_TEST,
     )
@@ -60,9 +63,11 @@ def test_aemo_representation_chain_custom_prompt(start_task_context: str):
     assert result.get("aemo_representation_context") is not None
 
 
-def test_aemo_representation_chain_task_step(start_task_context: str):
-    llm = create_chat_openai(profile="glm4_plus_low_temp")
-    kor_dreams_task_step_llm = create_chat_openai(profile="glm4_plus_guidance")
+def test_aemo_representation_chain_task_step(
+    start_task_context: str, chat_openai_factory: Callable[..., object]
+):
+    llm = chat_openai_factory(profile="glm4_plus_low_temp")
+    kor_dreams_task_step_llm = chat_openai_factory(profile="glm4_plus_guidance")
     from tests.integration_tests.test_aemo_representation_chain.prompts import (
         AEMO_REPRESENTATION_PROMPT_TEMPLATE as AEMO_REPRESENTATION_PROMPT_TEMPLATE_TEST,
     )
@@ -89,9 +94,11 @@ def test_aemo_representation_chain_task_step(start_task_context: str):
     assert len(task_step_iter) > 0
 
 
-def test_aemo_representation_chain_task_step_store(start_task_context: str):
-    llm = create_chat_openai(profile="glm4_plus_low_temp")
-    kor_dreams_task_step_llm = create_chat_openai(profile="glm4_plus_guidance")
+def test_aemo_representation_chain_task_step_store(
+    start_task_context: str, chat_openai_factory: Callable[..., object]
+):
+    llm = chat_openai_factory(profile="glm4_plus_low_temp")
+    kor_dreams_task_step_llm = chat_openai_factory(profile="glm4_plus_guidance")
     from tests.integration_tests.test_aemo_representation_chain.prompts import (
         AEMO_REPRESENTATION_PROMPT_TEMPLATE as AEMO_REPRESENTATION_PROMPT_TEMPLATE_TEST,
     )

--- a/src/dreamsboard/tests/integration_tests/test_batch_extract/test_batch_extract.py
+++ b/src/dreamsboard/tests/integration_tests/test_batch_extract/test_batch_extract.py
@@ -5,6 +5,7 @@ import re
 import shutil
 import time
 from pathlib import Path
+from typing import Callable
 
 import langchain
 from tqdm import tqdm
@@ -36,9 +37,6 @@ handler.setLevel(logging.DEBUG)
 logger.addHandler(handler)
 from langchain.callbacks import wandb_tracing_enabled
 
-from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
-
-
 def check_and_convert_special_characters(text):
     # 将除了中文之外的所有字符转换成\U
     converted_text = "".join(
@@ -47,7 +45,7 @@ def check_and_convert_special_characters(text):
     return converted_text
 
 
-def test_batch_extract(setup_log) -> None:
+def test_batch_extract(setup_log, chat_openai_factory: Callable[..., object]) -> None:
     with wandb_tracing_enabled():
         data_folder = "/media/gpt4-pdf-chatbot-langchain/InterpretationoDreams/社会交流步骤分析/msg_extract_csv"
         save_folder = "/media/gpt4-pdf-chatbot-langchain/InterpretationoDreams/社会交流步骤分析/msg_extract_storage_deepseek"
@@ -56,7 +54,7 @@ def test_batch_extract(setup_log) -> None:
             ds_path.mkdir()
         txt_files = load_csv(data_folder)
         logger.info("获取数据，成功{}".format(len(txt_files)))
-        llm = create_chat_openai(profile="deepseek_base")
+        llm = chat_openai_factory(profile="deepseek_base")
 
         # guidance_llm = ChatOpenAI(
         #     openai_api_base='http://127.0.0.1:30000/v1',
@@ -66,8 +64,8 @@ def test_batch_extract(setup_log) -> None:
         #     temperature=0.1,
         #     top_p=0.9,
         # )
-        guidance_llm = create_chat_openai(profile="deepseek_guidance")
-        personality_llm = create_chat_openai(profile="deepseek_guidance")
+        guidance_llm = chat_openai_factory(profile="deepseek_guidance")
+        personality_llm = chat_openai_factory(profile="deepseek_guidance")
         batch_len = 10
 
         # 对每一个文件进行操作

--- a/src/dreamsboard/tests/integration_tests/test_builder_task_step/test_builder_task_step.py
+++ b/src/dreamsboard/tests/integration_tests/test_builder_task_step/test_builder_task_step.py
@@ -2,6 +2,7 @@ import logging
 import multiprocessing
 import os
 import queue
+from typing import Callable
 
 from dreamsboard.common import _get_assistants_tool
 from dreamsboard.common.try_parse_json_object import try_parse_json_object
@@ -22,8 +23,6 @@ from langchain_community.document_loaders import UnstructuredPDFLoader
 from dreamsboard.engine.task_engine_builder.core import TaskEngineBuilder
 from dreamsboard.engine.utils import concat_dirs
 from dreamsboard.common.callback import process_registry
-
-from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -51,10 +50,12 @@ logger.addHandler(handler)
 
 
 def test_builder_task_step(
-    cross_encoder_path: str, embed_model_path: str
-):
-    llm = create_chat_openai(profile="openai_builder_base")
-    kor_dreams_task_step_llm = create_chat_openai(profile="openai_builder_guidance")
+    chat_openai_factory: Callable[..., object],
+    cross_encoder_path: str,
+    embed_model_path: str,
+) -> None:
+    llm = chat_openai_factory(profile="openai_builder_base")
+    kor_dreams_task_step_llm = chat_openai_factory(profile="openai_builder_guidance")
 
     if "glm" in (os.environ.get("OPENAI_MODEL_NAME") or ""):
         tools = [
@@ -118,10 +119,12 @@ def test_builder_task_step(
 
 
 def test_builder_task_step_answer(
-    cross_encoder_path: str, embed_model_path: str
-):
-    llm = create_chat_openai(profile="openai_builder_base")
-    kor_dreams_task_step_llm = create_chat_openai(profile="openai_builder_guidance")
+    chat_openai_factory: Callable[..., object],
+    cross_encoder_path: str,
+    embed_model_path: str,
+) -> None:
+    llm = chat_openai_factory(profile="openai_builder_base")
+    kor_dreams_task_step_llm = chat_openai_factory(profile="openai_builder_guidance")
 
     if "glm" in (os.environ.get("OPENAI_MODEL_NAME") or ""):
         tools = [
@@ -208,10 +211,12 @@ def test_json_parse():
 
 
 def test_builder_task_step_mctsr(
-    cross_encoder_path: str, embed_model_path: str
-):
-    llm = create_chat_openai(profile="openai_builder_base")
-    kor_dreams_task_step_llm = create_chat_openai(profile="openai_builder_guidance")
+    chat_openai_factory: Callable[..., object],
+    cross_encoder_path: str,
+    embed_model_path: str,
+) -> None:
+    llm = chat_openai_factory(profile="openai_builder_base")
+    kor_dreams_task_step_llm = chat_openai_factory(profile="openai_builder_guidance")
 
     if "glm" in (os.environ.get("OPENAI_MODEL_NAME") or ""):
         tools = [
@@ -324,12 +329,16 @@ def test_task_step_md():
 
 
 def test_builder_task_step_mctsr_threads(
-    setup_log, cross_encoder_path: str, embed_model_path: str
-):
+    setup_log,
+    chat_openai_factory: Callable[..., object],
+    cross_encoder_path: str,
+    embed_model_path: str,
+) -> None:
     import threading
-    llm = create_chat_openai(profile="deepseek_env_primary")
 
-    guiji_llm = create_chat_openai(profile="deepseek_env_secondary")
+    llm = chat_openai_factory(profile="deepseek_env_primary")
+
+    guiji_llm = chat_openai_factory(profile="deepseek_env_secondary")
     llm_with_tools = llm
     kor_dreams_task_step_llm_with_tools = guiji_llm
 
@@ -508,7 +517,7 @@ def test_builder_task_step_mctsr_threads(
         t.join()
 
 
-def test_prompt():
+def test_prompt(chat_openai_factory: Callable[..., object]) -> None:
     
  
 
@@ -539,7 +548,7 @@ def test_prompt():
     ),
     )
 
-    llm_runable = create_chat_openai(profile="deepseek_env_longform")
+    llm_runable = chat_openai_factory(profile="deepseek_env_longform")
 
     aemo_representation_chain = prompt_template1 | llm_runable | StrOutputParser()
 

--- a/src/dreamsboard/tests/integration_tests/test_engine.py
+++ b/src/dreamsboard/tests/integration_tests/test_engine.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from typing import Any, Callable
 
 import langchain
 from langchain.prompts import PromptTemplate
@@ -8,8 +9,6 @@ from langchain_community.adapters.openai import (
     convert_dict_to_message,
     convert_message_to_dict,
 )
-
-from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
 from dreamsboard.engine.engine_builder import CodeGeneratorBuilder
 from dreamsboard.engine.generate.code_generate import (
@@ -96,8 +95,8 @@ def test_engine() -> None:
     assert True
 
 
-def test_code():
-    llm = create_chat_openai(profile="glm4_airx_guidance")
+def test_code(chat_openai_factory: Callable[..., Any]) -> None:
+    llm = chat_openai_factory(profile="glm4_airx_guidance")
     critic_system_prompt_template = PromptTemplate(
         input_variables=[
             "problem",

--- a/src/dreamsboard/tests/integration_tests/test_engine_storyboard.py
+++ b/src/dreamsboard/tests/integration_tests/test_engine_storyboard.py
@@ -1,8 +1,7 @@
 import logging
+from typing import Callable
 
 import langchain
-
-from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
 from dreamsboard.dreams.builder_cosplay_code.base import StructuredDreamsStoryboard
 from dreamsboard.dreams.dreams_personality_chain.base import (
@@ -20,8 +19,10 @@ handler.setLevel(logging.DEBUG)
 logger.addHandler(handler)
 
 
-def test_structured_dreams_storyboard() -> None:
-    llm = create_chat_openai(profile="verbose")
+def test_structured_dreams_storyboard(
+    chat_openai_factory: Callable[..., object]
+) -> None:
+    llm = chat_openai_factory(profile="verbose")
 
     dreams_generation_chain = StoryBoardDreamsGenerationChain.from_dreams_personality_chain(
         llm_runable=llm,

--- a/src/dreamsboard/tests/integration_tests/test_gpt4o/test_engine_storyboard_store_test_gpt4o.py
+++ b/src/dreamsboard/tests/integration_tests/test_gpt4o/test_engine_storyboard_store_test_gpt4o.py
@@ -1,11 +1,10 @@
 import logging
+from typing import Callable
 
 import langchain
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import PromptTemplate
 from langchain_core.runnables import RunnableLambda
-
-from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
 from dreamsboard.document_loaders import StructuredStoryboardCSVBuilder
 from dreamsboard.dreams.builder_cosplay_code.base import StructuredDreamsStoryboard
@@ -38,9 +37,11 @@ handler.setLevel(logging.DEBUG)
 logger.addHandler(handler)
 
 
-def test_structured_dreams_storyboard_store_test_gpt4o(setup_log) -> None:
-    llm = create_chat_openai(profile="gpt4o")
-    guidance_llm = create_chat_openai(profile="gpt4o_guidance")
+def test_structured_dreams_storyboard_store_test_gpt4o(
+    setup_log, chat_openai_factory: Callable[..., object]
+) -> None:
+    llm = chat_openai_factory(profile="gpt4o")
+    guidance_llm = chat_openai_factory(profile="gpt4o_guidance")
     try:
         storage_context = StorageContext.from_defaults(
             persist_dir="./ieAjabk1_keyframe"

--- a/src/dreamsboard/tests/integration_tests/test_kor/test_kor1.py
+++ b/src/dreamsboard/tests/integration_tests/test_kor/test_kor1.py
@@ -1,13 +1,12 @@
 import os
+from typing import Callable
 
 from kor.extraction import create_extraction_chain
 from kor.nodes import Number, Object, Text
 
-from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
-
-def test_kor():
-    llm = create_chat_openai(profile="glm3_local_guidance")
+def test_kor(chat_openai_factory: Callable[..., object]) -> None:
+    llm = chat_openai_factory(profile="glm3_local_guidance")
     # @title 长的prompt
 
     schema = Object(

--- a/src/dreamsboard/tests/integration_tests/test_kor/test_kor2.py
+++ b/src/dreamsboard/tests/integration_tests/test_kor/test_kor2.py
@@ -1,13 +1,12 @@
 import os
+from typing import Callable
 
 from kor.extraction import create_extraction_chain
 from kor.nodes import Number, Object, Text
 
-from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
-
-def test_kor2():
-    llm = create_chat_openai(profile="glm4_local_low_temp")
+def test_kor2(chat_openai_factory: Callable[..., object]) -> None:
+    llm = chat_openai_factory(profile="glm4_local_low_temp")
     # @title 长的prompt
     schema = Object(
         id="script",

--- a/src/dreamsboard/tests/integration_tests/test_kor/test_kor3.py
+++ b/src/dreamsboard/tests/integration_tests/test_kor/test_kor3.py
@@ -1,13 +1,12 @@
 import os
+from typing import Callable
 
 from kor.extraction import create_extraction_chain
 from kor.nodes import Number, Object, Text
 
-from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
-
-def test_kor3():
-    llm = create_chat_openai(profile="glm4_remote_low_temp")
+def test_kor3(chat_openai_factory: Callable[..., object]) -> None:
+    llm = chat_openai_factory(profile="glm4_remote_low_temp")
     # @title 长的prompt
     schema = Object(
         id="script",

--- a/src/dreamsboard/tests/integration_tests/test_runnable/test_create_structured_output_runnable.py
+++ b/src/dreamsboard/tests/integration_tests/test_runnable/test_create_structured_output_runnable.py
@@ -1,12 +1,10 @@
 import logging
-from typing import Optional
+from typing import Callable, Optional
 
 import langchain
 from langchain.chains.openai_functions import create_structured_output_runnable
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.pydantic_v1 import BaseModel, Field
-
-from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
 langchain.verbose = True
 logger = logging.getLogger(__name__)
@@ -25,9 +23,11 @@ class Personality(BaseModel):
     personality: str = Field(..., description="性格评价")
 
 
-def test_create_structured_output_runnable() -> None:
+def test_create_structured_output_runnable(
+    chat_openai_factory: Callable[..., object]
+) -> None:
     """Test create_structured_output_runnable. 测试创建结构化输出可运行对象。"""
-    llm = create_chat_openai(profile="glm4_local_verbose")
+    llm = chat_openai_factory(profile="glm4_local_verbose")
     prompt = ChatPromptTemplate.from_messages(
         [
             (

--- a/src/dreamsboard/tests/integration_tests/test_runnable/test_create_structured_output_runnable2.py
+++ b/src/dreamsboard/tests/integration_tests/test_runnable/test_create_structured_output_runnable2.py
@@ -1,12 +1,10 @@
 import logging
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 import langchain
 from langchain.chains.openai_functions import create_structured_output_runnable
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.pydantic_v1 import BaseModel, Field
-
-from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
 from dreamsboard.document_loaders.protocol.ner_protocol import (
     DreamsStepInfo,
@@ -24,9 +22,11 @@ handler.setLevel(logging.DEBUG)
 logger.addHandler(handler)
 
 
-def test_create_structured_output_runnable2() -> None:
+def test_create_structured_output_runnable2(
+    chat_openai_factory: Callable[..., object]
+) -> None:
     """Test create_structured_output_runnable. 测试创建结构化输出可运行对象。"""
-    llm = create_chat_openai(profile="glm4_local_low_temp")
+    llm = chat_openai_factory(profile="glm4_local_low_temp")
     prompt = ChatPromptTemplate.from_messages(
         [
             (

--- a/src/dreamsboard/tests/integration_tests/test_runnable_itemgetter/test_runnable_parallel_chain.py
+++ b/src/dreamsboard/tests/integration_tests/test_runnable_itemgetter/test_runnable_parallel_chain.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import Callable, Optional
 
 import langchain
 from langchain.chains.openai_functions import create_structured_output_runnable
@@ -9,8 +9,6 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.pydantic_v1 import BaseModel, Field
 from langchain_core.runnables import RunnablePassthrough
 from langchain_openai import OpenAIEmbeddings
-
-from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
 langchain.verbose = True
 logger = logging.getLogger(__name__)
@@ -23,13 +21,15 @@ handler.setLevel(logging.DEBUG)
 logger.addHandler(handler)
 
 
-def test_runnable_parallel_chain() -> None:
+def test_runnable_parallel_chain(
+    chat_openai_factory: Callable[..., object]
+) -> None:
     """Test create_structured_output_runnable. 测试创建结构化输出可运行对象。"""
 
     from langchain_core.prompts import ChatPromptTemplate
     from langchain_core.runnables import RunnableParallel
 
-    llm = create_chat_openai(profile="glm4_local_verbose")
+    llm = chat_openai_factory(profile="glm4_local_verbose")
     joke_chain = (
         ChatPromptTemplate.from_template("tell me a joke about {topic}")
         | llm

--- a/src/dreamsboard/tests/integration_tests/test_structured_storyboard_loader/test_structured_storyboard_loader.py
+++ b/src/dreamsboard/tests/integration_tests/test_structured_storyboard_loader/test_structured_storyboard_loader.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from typing import Callable
 
 from dreamsboard.document_loaders.structured_storyboard_loader import (
     StructuredStoryboard,
@@ -11,8 +12,6 @@ from dreamsboard.engine.storage.task_step_store.simple_task_step_store import (
     SimpleTaskStepStore,
 )
 from dreamsboard.engine.utils import concat_dirs
-
-from dreamsboard.tests.integration_tests.utils.environment import create_chat_openai
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -30,9 +29,11 @@ logger.addHandler(handler)
 """
 
 
-def test_structured_storyboard_loader(start_task_context: str):
-    llm = create_chat_openai(profile="glm4_plus_low_temp")
-    kor_dreams_task_step_llm = create_chat_openai(profile="glm4_plus_guidance")
+def test_structured_storyboard_loader(
+    start_task_context: str, chat_openai_factory: Callable[..., object]
+):
+    llm = chat_openai_factory(profile="glm4_plus_low_temp")
+    kor_dreams_task_step_llm = chat_openai_factory(profile="glm4_plus_guidance")
     from tests.integration_tests.test_aemo_representation_chain.prompts import (
         AEMO_REPRESENTATION_PROMPT_TEMPLATE as AEMO_REPRESENTATION_PROMPT_TEMPLATE_TEST,
     )

--- a/src/dreamsboard/tests/integration_tests/utils/environment.py
+++ b/src/dreamsboard/tests/integration_tests/utils/environment.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Type
 
 import pytest
 
@@ -236,18 +236,6 @@ def get_chat_openai_profile(profile: str = "default") -> Dict[str, Any]:
     return CHAT_OPENAI_PROFILES[profile].copy()
 
 
-def create_chat_openai(profile: str = "default", **overrides: Any) -> Any:
-    """Instantiate a ChatOpenAI-compatible object using an environment profile."""
-
-    ensure_external_services_available()
-    params = get_chat_openai_profile(profile)
-    params.update(overrides)
-    params = {key: value for key, value in params.items() if value is not None}
-
-    chat_cls = resolve_chat_openai_class()
-    return chat_cls(**params)
-
-
 __all__ = [
     "ALL_ENV_VARS",
     "CHAT_OPENAI_DEFAULTS",
@@ -257,7 +245,6 @@ __all__ = [
     "REQUIRED_ENV_VARS",
     "SKIP_MESSAGE",
     "START_TASK_CONTEXT",
-    "create_chat_openai",
     "ensure_external_services_available",
     "get_chat_openai_profile",
     "get_env_path",


### PR DESCRIPTION
## Summary
- drop the unused `chat_openai` fixture now that tests rely on `chat_openai_factory`
- remove the legacy `create_chat_openai` helper from the integration environment utilities and its exports
- update the integration test README to document the `chat_openai_factory` usage pattern

## Testing
- python -m compileall src/dreamsboard/tests/integration_tests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911dbbc07608327a264ae55a93d0742)