### PR TITLE
Revise ChatOpenAI profile loading for integration tests

### DIFF
--- a/src/dreamsboard/tests/integration_tests/config/chat_openai_profiles.json
+++ b/src/dreamsboard/tests/integration_tests/config/chat_openai_profiles.json
@@ -1,180 +1,136 @@
 {
   "profiles": {
     "default": {
-      "parameters": {}
+      "openai_api_base": "env:OPENAI_API_BASE||https://api.openai.com/v1",
+      "model": "env:OPENAI_MODEL_NAME||gpt-4o-mini",
+      "openai_api_key": "env:OPENAI_API_KEY",
+      "verbose": "env:OPENAI_VERBOSE||false",
+      "temperature": 0.95,
+      "top_p": 0.7
     },
     "verbose": {
       "inherit": "default",
-      "parameters": {
-        "verbose": true
-      }
+      "verbose": true
     },
     "gpt4o": {
       "inherit": "verbose",
-      "parameters": {
-        "model": "gpt-4o"
-      }
+      "model": "env:GPT4O_MODEL_NAME||gpt-4o"
     },
     "gpt4o_guidance": {
       "inherit": "gpt4o",
-      "parameters": {
-        "temperature": 0.95,
-        "top_p": 0.7
-      }
+      "temperature": 0.95,
+      "top_p": 0.7
     },
     "deepseek_base": {
-      "parameters": {
-        "openai_api_base": "http://127.0.0.1:20000/deepseek/v1",
-        "model": "deepseek-chat",
-        "openai_api_key": "sk-c7balko7z4266rye",
-        "verbose": true
-      }
+      "openai_api_base": "env:DEEPSEEK_API_BASE||http://127.0.0.1:20000/deepseek/v1",
+      "model": "env:DEEPSEEK_API_MODEL||deepseek-chat",
+      "openai_api_key": "env:DEEPSEEK_API_KEY||env:OPENAI_API_KEY",
+      "verbose": "env:DEEPSEEK_VERBOSE||true",
+      "temperature": 0.95,
+      "top_p": 0.7
     },
     "deepseek_guidance": {
       "inherit": "deepseek_base",
-      "parameters": {
-        "temperature": 0.95,
-        "top_p": 0.7
-      }
+      "temperature": 0.95,
+      "top_p": 0.7
     },
     "deepseek_env_primary": {
-      "parameters": {
-        "openai_api_base": "env:DEEPSEEK_API_BASE||env:OPENAI_API_BASE",
-        "model": "env:DEEPSEEK_API_MODEL||env:OPENAI_MODEL_NAME",
-        "openai_api_key": "env:DEEPSEEK_API_KEY||env:OPENAI_API_KEY",
-        "verbose": true,
-        "temperature": 0.9,
-        "top_p": 0.9,
-        "max_tokens": 4000
-      }
+      "openai_api_base": "env:DEEPSEEK_API_BASE||env:OPENAI_API_BASE",
+      "model": "env:DEEPSEEK_API_MODEL||env:OPENAI_MODEL_NAME",
+      "openai_api_key": "env:DEEPSEEK_API_KEY||env:OPENAI_API_KEY",
+      "verbose": true,
+      "temperature": 0.9,
+      "top_p": 0.9
     },
     "deepseek_env_secondary": {
       "inherit": "deepseek_env_primary",
-      "parameters": {
-        "temperature": 0.1
-      }
+      "temperature": 0.1
     },
     "deepseek_env_longform": {
-      "inherit": "deepseek_env_primary",
-      "parameters": {
-        "max_tokens": 8192
-      }
+      "inherit": "deepseek_env_primary"
     },
     "openai_builder_base": {
-      "parameters": {
-        "openai_api_base": "env:OPENAI_API_BASE",
-        "model": "env:OPENAI_MODEL_NAME",
-        "openai_api_key": "env:OPENAI_API_KEY",
-        "verbose": true,
-        "temperature": 0.1,
-        "top_p": 0.9
-      }
+      "openai_api_base": "env:OPENAI_API_BASE",
+      "model": "env:OPENAI_MODEL_NAME",
+      "openai_api_key": "env:OPENAI_API_KEY",
+      "verbose": true,
+      "temperature": 0.1,
+      "top_p": 0.9
     },
     "openai_builder_guidance": {
       "inherit": "openai_builder_base",
-      "parameters": {
-        "temperature": 0.95,
-        "top_p": 0.7
-      }
+      "temperature": 0.95,
+      "top_p": 0.7
     },
     "glm4_gateway_guidance": {
-      "parameters": {
-        "openai_api_base": "http://0.0.0.0:8000/v1",
-        "model": "glm-4",
-        "openai_api_key": "glm-4",
-        "verbose": true,
-        "temperature": 0.95,
-        "top_p": 0.7
-      }
+      "openai_api_base": "env:GLM4_GATEWAY_API_BASE||http://0.0.0.0:8000/v1",
+      "model": "env:GLM4_GATEWAY_MODEL||glm-4",
+      "openai_api_key": "env:GLM4_GATEWAY_API_KEY||glm-4",
+      "verbose": true,
+      "temperature": 0.95,
+      "top_p": 0.7
     },
     "glm4_remote_guidance": {
-      "parameters": {
-        "openai_api_base": "https://open.bigmodel.cn/api/paas/v4",
-        "model": "glm-4",
-        "openai_api_key": "testkey",
-        "verbose": true,
-        "temperature": 0.95,
-        "top_p": 0.7
-      }
+      "openai_api_base": "env:GLM4_API_BASE||https://open.bigmodel.cn/api/paas/v4",
+      "model": "env:GLM4_MODEL_NAME||glm-4",
+      "openai_api_key": "env:GLM4_API_KEY||testkey",
+      "verbose": true,
+      "temperature": 0.95,
+      "top_p": 0.7
     },
     "glm4_remote_guidance_slash": {
-      "parameters": {
-        "openai_api_base": "https://open.bigmodel.cn/api/paas/v4/",
-        "model": "glm-4",
-        "openai_api_key": "testkey",
-        "verbose": true,
-        "temperature": 0.95,
-        "top_p": 0.7
-      }
+      "inherit": "glm4_remote_guidance",
+      "openai_api_base": "env:GLM4_API_BASE_SLASH||https://open.bigmodel.cn/api/paas/v4/"
     },
     "glm4_remote_low_temp": {
-      "parameters": {
-        "openai_api_base": "https://open.bigmodel.cn/api/paas/v4",
-        "model": "glm-4",
-        "openai_api_key": "testkey",
-        "verbose": true,
-        "temperature": 0.1,
-        "top_p": 0.9
-      }
+      "inherit": "glm4_remote_guidance",
+      "temperature": 0.1,
+      "top_p": 0.9
     },
     "glm4_local_verbose": {
-      "parameters": {
-        "openai_api_base": "http://127.0.0.1:30000/v1",
-        "model": "glm-4",
-        "openai_api_key": "glm-4",
-        "verbose": true
-      }
+      "openai_api_base": "env:GLM4_LOCAL_API_BASE||http://127.0.0.1:30000/v1",
+      "model": "env:GLM4_LOCAL_MODEL||glm-4",
+      "openai_api_key": "env:GLM4_LOCAL_API_KEY||glm-4",
+      "verbose": true
     },
     "glm4_local_low_temp": {
       "inherit": "glm4_local_verbose",
-      "parameters": {
-        "temperature": 0.1,
-        "top_p": 0.9
-      }
+      "temperature": 0.1,
+      "top_p": 0.9
     },
     "glm4_local_guidance": {
       "inherit": "glm4_local_verbose",
-      "parameters": {
-        "temperature": 0.95,
-        "top_p": 0.7
-      }
+      "temperature": 0.95,
+      "top_p": 0.7
     },
     "glm3_local_guidance": {
-      "parameters": {
-        "openai_api_base": "http://127.0.0.1:30000/v1",
-        "model": "glm-3-turbo",
-        "openai_api_key": "glm-4",
-        "verbose": true,
-        "temperature": 0.95,
-        "top_p": 0.7
-      }
+      "openai_api_base": "env:GLM3_LOCAL_API_BASE||http://127.0.0.1:30000/v1",
+      "model": "env:GLM3_LOCAL_MODEL||glm-3-turbo",
+      "openai_api_key": "env:GLM3_LOCAL_API_KEY||glm-4",
+      "verbose": true,
+      "temperature": 0.95,
+      "top_p": 0.7
     },
     "glm4_airx_guidance": {
-      "parameters": {
-        "openai_api_base": "https://open.bigmodel.cn/api/paas/v4/",
-        "model": "glm-4-airx",
-        "openai_api_key": "12",
-        "verbose": true,
-        "temperature": 0.95,
-        "top_p": 0.7
-      }
+      "openai_api_base": "env:GLM4_AIRX_API_BASE||https://open.bigmodel.cn/api/paas/v4/",
+      "model": "env:GLM4_AIRX_MODEL||glm-4-airx",
+      "openai_api_key": "env:GLM4_AIRX_API_KEY||12",
+      "verbose": true,
+      "temperature": 0.95,
+      "top_p": 0.7
     },
     "glm4_plus_low_temp": {
-      "parameters": {
-        "openai_api_base": "https://open.bigmodel.cn/api/paas/v4",
-        "model": "glm-4-plus",
-        "openai_api_key": "testkey",
-        "verbose": true,
-        "temperature": 0.1,
-        "top_p": 0.9
-      }
+      "openai_api_base": "env:GLM4_PLUS_API_BASE||https://open.bigmodel.cn/api/paas/v4",
+      "model": "env:GLM4_PLUS_MODEL||glm-4-plus",
+      "openai_api_key": "env:GLM4_PLUS_API_KEY||testkey",
+      "verbose": true,
+      "temperature": 0.1,
+      "top_p": 0.9
     },
     "glm4_plus_guidance": {
       "inherit": "glm4_plus_low_temp",
-      "parameters": {
-        "temperature": 0.95,
-        "top_p": 0.7
-      }
+      "temperature": 0.95,
+      "top_p": 0.7
     }
   }
 }

--- a/src/dreamsboard/tests/integration_tests/utils/environment.py
+++ b/src/dreamsboard/tests/integration_tests/utils/environment.py
@@ -10,6 +10,7 @@ or ``CHAT_OPENAI_PROFILES_JSON``.
 
 from __future__ import annotations
 
+import importlib
 import json
 import os
 from pathlib import Path
@@ -51,6 +52,46 @@ ENV_VALUE_PREFIX = "env:"
 CHAT_OPENAI_PROFILE_SKIP_TEMPLATE = (
     "Skipping test: ChatOpenAI profile '{profile}' requires '{variable}'."
 )
+
+_DOTENV_LOADED = False
+
+
+def _ensure_dotenv_loaded() -> None:
+    """Load ``.env`` configuration once when available."""
+
+    global _DOTENV_LOADED
+    if _DOTENV_LOADED:
+        return
+
+    spec = importlib.util.find_spec("dotenv")
+    if spec is None:
+        _DOTENV_LOADED = True
+        return
+
+    dotenv_module = importlib.import_module("dotenv")
+    load_dotenv = getattr(dotenv_module, "load_dotenv", None)
+    find_dotenv = getattr(dotenv_module, "find_dotenv", None)
+
+    if load_dotenv is None:
+        _DOTENV_LOADED = True
+        return
+
+    if find_dotenv is not None:
+        env_path = find_dotenv(usecwd=True)
+        if env_path:
+            load_dotenv(env_path, override=False)
+        else:
+            load_dotenv(override=False)
+    else:
+        load_dotenv(override=False)
+
+    search_roots = [Path.cwd()] + list(Path(__file__).resolve().parents)
+    for root in search_roots:
+        env_candidate = root / ".env"
+        if env_candidate.exists():
+            load_dotenv(env_candidate, override=False)
+
+    _DOTENV_LOADED = True
 
 
 def missing_required_env_vars(env: Iterable[str] | None = None) -> List[str]:
@@ -159,6 +200,16 @@ def _raw_chat_openai_profiles() -> Dict[str, Any]:
     return profiles
 
 
+def _coerce_env_literal(value: str) -> Any:
+    lowered = value.lower()
+    if lowered in {"true", "false"}:
+        return lowered == "true"
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return value
+
+
 def _resolve_profile_value(
     profile: str, key: str, value: Any, skip_message: str
 ) -> Any:
@@ -170,13 +221,13 @@ def _resolve_profile_value(
             if fallback:
                 if fallback.startswith(ENV_VALUE_PREFIX):
                     return _resolve_profile_value(profile, key, fallback, skip_message)
-                return fallback
+                return _coerce_env_literal(fallback)
             pytest.skip(
                 CHAT_OPENAI_PROFILE_SKIP_TEMPLATE.format(
                     profile=profile, variable=variable
                 )
             )
-        return env_value
+        return _coerce_env_literal(env_value)
     if value == "<skip>":
         pytest.skip(skip_message)
     return value
@@ -222,12 +273,19 @@ def _build_chat_openai_profiles() -> Dict[str, Dict[str, Any]]:
     return built
 
 
-CHAT_OPENAI_PROFILES: Dict[str, Dict[str, Any]] = _build_chat_openai_profiles()
+def _resolve_chat_openai_profiles() -> Dict[str, Dict[str, Any]]:
+    _ensure_dotenv_loaded()
+    return _build_chat_openai_profiles()
+
+
+CHAT_OPENAI_PROFILES: Dict[str, Dict[str, Any]] = _resolve_chat_openai_profiles()
 
 
 def get_chat_openai_profile(profile: str = "default") -> Dict[str, Any]:
     """Return the resolved ChatOpenAI parameter set for ``profile``."""
 
+    global CHAT_OPENAI_PROFILES
+    CHAT_OPENAI_PROFILES = _resolve_chat_openai_profiles()
     if profile not in CHAT_OPENAI_PROFILES:
         available = ", ".join(sorted(CHAT_OPENAI_PROFILES))
         raise KeyError(


### PR DESCRIPTION
## Summary
- load `.env` files before resolving ChatOpenAI integration profiles
- coerce environment-driven values and refresh profile resolution each call
- restore integration ChatOpenAI profile definitions in `config/chat_openai_profiles.json` so tests resolve names from the shared config with env-aware defaults

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911e934f64483278a3ce42fd9dc2c47)